### PR TITLE
Release v0.15.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,12 +149,12 @@ Get the latest version — no account required, just install and start writing. 
 
 | Platform | Download |
 |----------|----------|
-| **macOS** (Apple Silicon) | [Download .dmg](https://github.com/Proteus-Technologies-Private-Limited/OpenDraft/releases/latest/download/OpenDraft_0.14.1_aarch64.dmg) |
-| **Windows** (64-bit) | [Download .exe](https://github.com/Proteus-Technologies-Private-Limited/OpenDraft/releases/latest/download/OpenDraft_0.14.1_x64-setup.exe) |
-| **Windows** (MSI) | [Download .msi](https://github.com/Proteus-Technologies-Private-Limited/OpenDraft/releases/latest/download/OpenDraft_0.14.1_x64_en-US.msi) |
-| **Linux** (Debian/Ubuntu) | [Download .deb](https://github.com/Proteus-Technologies-Private-Limited/OpenDraft/releases/latest/download/OpenDraft_0.14.1_amd64.deb) |
-| **Linux** (AppImage) | [Download .AppImage](https://github.com/Proteus-Technologies-Private-Limited/OpenDraft/releases/latest/download/OpenDraft_0.14.1_amd64.AppImage) |
-| **Linux** (RPM/Fedora) | [Download .rpm](https://github.com/Proteus-Technologies-Private-Limited/OpenDraft/releases/latest/download/OpenDraft-0.14.1-1.x86_64.rpm) |
+| **macOS** (Apple Silicon) | [Download .dmg](https://github.com/Proteus-Technologies-Private-Limited/OpenDraft/releases/latest/download/OpenDraft_0.15.0_aarch64.dmg) |
+| **Windows** (64-bit) | [Download .exe](https://github.com/Proteus-Technologies-Private-Limited/OpenDraft/releases/latest/download/OpenDraft_0.15.0_x64-setup.exe) |
+| **Windows** (MSI) | [Download .msi](https://github.com/Proteus-Technologies-Private-Limited/OpenDraft/releases/latest/download/OpenDraft_0.15.0_x64_en-US.msi) |
+| **Linux** (Debian/Ubuntu) | [Download .deb](https://github.com/Proteus-Technologies-Private-Limited/OpenDraft/releases/latest/download/OpenDraft_0.15.0_amd64.deb) |
+| **Linux** (AppImage) | [Download .AppImage](https://github.com/Proteus-Technologies-Private-Limited/OpenDraft/releases/latest/download/OpenDraft_0.15.0_amd64.AppImage) |
+| **Linux** (RPM/Fedora) | [Download .rpm](https://github.com/Proteus-Technologies-Private-Limited/OpenDraft/releases/latest/download/OpenDraft-0.15.0-1.x86_64.rpm) |
 
 ### Mobile
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -25,7 +25,7 @@ async def lifespan(app: FastAPI):
 app = FastAPI(
     title="OpenDraft API",
     description="Backend API for OpenDraft screenwriting application",
-    version="0.14.1",
+    version="0.15.0",
     lifespan=lifespan,
 )
 

--- a/frontend/src/components/MenuBar.tsx
+++ b/frontend/src/components/MenuBar.tsx
@@ -1088,7 +1088,7 @@ const MenuBar: React.FC<MenuBarProps> = ({ editor, onCollaborate, onJoinCollab, 
           <div className="dialog-header">About Open Draft</div>
           <div className="dialog-body about-body">
             <div className="about-title">Open Draft</div>
-            <div className="about-version">Version 0.14.1</div>
+            <div className="about-version">Version 0.15.0</div>
             <div className="about-tagline">Free, open-source screenwriting software</div>
 
             <div className="about-whats-new">

--- a/landing/index.html
+++ b/landing/index.html
@@ -675,17 +675,17 @@
         <p class="section-desc">Available on every major platform. Free, no account needed. Most users are writing in under 2 minutes.</p>
       </div>
       <div class="download-grid">
-        <a href="https://github.com/Proteus-Technologies-Private-Limited/OpenDraft/releases/latest/download/OpenDraft_0.14.1_aarch64.dmg" class="download-card">
+        <a href="https://github.com/Proteus-Technologies-Private-Limited/OpenDraft/releases/latest/download/OpenDraft_0.15.0_aarch64.dmg" class="download-card">
           <svg class="platform-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5"><rect x="2" y="3" width="20" height="14" rx="2"/><line x1="8" y1="21" x2="16" y2="21"/><line x1="12" y1="17" x2="12" y2="21"/></svg>
           <h3>macOS</h3>
           <p>Apple Silicon .dmg</p>
         </a>
-        <a href="https://github.com/Proteus-Technologies-Private-Limited/OpenDraft/releases/latest/download/OpenDraft_0.14.1_x64-setup.exe" class="download-card">
+        <a href="https://github.com/Proteus-Technologies-Private-Limited/OpenDraft/releases/latest/download/OpenDraft_0.15.0_x64-setup.exe" class="download-card">
           <svg class="platform-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5"><rect x="2" y="3" width="20" height="14" rx="2"/><line x1="8" y1="21" x2="16" y2="21"/><line x1="12" y1="17" x2="12" y2="21"/></svg>
           <h3>Windows</h3>
           <p>64-bit installer</p>
         </a>
-        <a href="https://github.com/Proteus-Technologies-Private-Limited/OpenDraft/releases/latest/download/OpenDraft_0.14.1_amd64.deb" class="download-card">
+        <a href="https://github.com/Proteus-Technologies-Private-Limited/OpenDraft/releases/latest/download/OpenDraft_0.15.0_amd64.deb" class="download-card">
           <svg class="platform-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5"><rect x="4" y="2" width="16" height="20" rx="2"/><line x1="12" y1="18" x2="12" y2="18.01"/></svg>
           <h3>Linux</h3>
           <p>.deb / .AppImage / .rpm</p>

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -355,9 +355,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.59"
+version = "1.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7a4d3ec6524d28a329fc53654bbadc9bdd7b0431f5d65f1a56ffb28a1ee5283"
+checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -1900,9 +1900,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.94"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e04e2ef80ce82e13552136fabeef8a5ed1f985a96805761cbb9a2c34e7664d9"
+checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -2018,14 +2018,14 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
-version = "0.1.15"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ddbf48fd451246b1f8c2610bd3b4ac0cc6e149d89832867093ab69a17194f08"
+checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
 dependencies = [
  "bitflags 2.11.0",
  "libc",
  "plain",
- "redox_syscall 0.7.3",
+ "redox_syscall 0.7.4",
 ]
 
 [[package]]
@@ -2435,7 +2435,7 @@ checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "opendraft"
-version = "0.14.1"
+version = "0.15.0"
 dependencies = [
  "jni",
  "ndk-context",
@@ -3123,9 +3123,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce70a74e890531977d37e532c34d45e9055d2409ed08ddba14529471ed0be16"
+checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
 dependencies = [
  "bitflags 2.11.0",
 ]
@@ -3416,9 +3416,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "20a6af516fea4b20eccceaf166e8aa666ac996208e8a644ce3ef5aa783bc7cd4"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -5204,9 +5204,9 @@ checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0551fc1bb415591e3372d0bc4780db7e587d84e2a7e79da121051c5c4b89d0b0"
+checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -5218,9 +5218,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.67"
+version = "0.4.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03623de6905b7206edd0a75f69f747f134b7f0a2323392d664448bf2d3c5d87e"
+checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5228,9 +5228,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fbdf9a35adf44786aecd5ff89b4563a90325f9da0923236f6104e603c7e86be"
+checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -5238,9 +5238,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dca9693ef2bab6d4e6707234500350d8dad079eb508dca05530c85dc3a529ff2"
+checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -5251,9 +5251,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39129a682a6d2d841b6c429d0c51e5cb0ed1a03829d8b3d1e69a011e62cb3d3b"
+checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
 dependencies = [
  "unicode-ident",
 ]
@@ -5307,9 +5307,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.94"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd70027e39b12f0849461e08ffc50b9cd7688d942c1c8e3c7b22273236b4dd0a"
+checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "opendraft"
-version = "0.14.1"
+version = "0.15.0"
 description = "OpenDraft - Professional Screenwriting Application"
 authors = ["OpenDraft"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-config-schema/schema.json",
   "productName": "OpenDraft",
-  "version": "0.14.1",
+  "version": "0.15.0",
   "identifier": "com.proteus.opendraft",
   "build": {
     "frontendDist": "../frontend/dist",

--- a/user-manual/beat-board.html
+++ b/user-manual/beat-board.html
@@ -171,7 +171,7 @@
 
   </div>
   <footer class="footer">
-    OpenDraft User Manual &middot; v0.14.1 &middot; Made by Proteus Technologies
+    OpenDraft User Manual &middot; v0.15.0 &middot; Made by Proteus Technologies
   </footer>
 </main>
 

--- a/user-manual/characters.html
+++ b/user-manual/characters.html
@@ -257,7 +257,7 @@
 
   </div>
   <footer class="footer">
-    OpenDraft User Manual &middot; v0.14.1 &middot; Made by Proteus Technologies
+    OpenDraft User Manual &middot; v0.15.0 &middot; Made by Proteus Technologies
   </footer>
 </main>
 

--- a/user-manual/collaboration.html
+++ b/user-manual/collaboration.html
@@ -238,7 +238,7 @@
 
   </div>
   <footer class="footer">
-    OpenDraft User Manual &middot; v0.14.1 &middot; Made by Proteus Technologies
+    OpenDraft User Manual &middot; v0.15.0 &middot; Made by Proteus Technologies
   </footer>
 </main>
 

--- a/user-manual/find-replace.html
+++ b/user-manual/find-replace.html
@@ -163,7 +163,7 @@
 
   </div>
   <footer class="footer">
-    OpenDraft User Manual &middot; v0.14.1 &middot; Made by Proteus Technologies
+    OpenDraft User Manual &middot; v0.15.0 &middot; Made by Proteus Technologies
   </footer>
 </main>
 

--- a/user-manual/formatting.html
+++ b/user-manual/formatting.html
@@ -370,7 +370,7 @@
 
   </div>
   <footer class="footer">
-    OpenDraft User Manual &middot; v0.14.1 &middot; Made by Proteus Technologies
+    OpenDraft User Manual &middot; v0.15.0 &middot; Made by Proteus Technologies
   </footer>
 </main>
 

--- a/user-manual/getting-started.html
+++ b/user-manual/getting-started.html
@@ -247,7 +247,7 @@
 
   </div>
   <footer class="footer">
-    OpenDraft User Manual &middot; v0.14.1 &middot; Made by Proteus Technologies
+    OpenDraft User Manual &middot; v0.15.0 &middot; Made by Proteus Technologies
   </footer>
 </main>
 

--- a/user-manual/import-export.html
+++ b/user-manual/import-export.html
@@ -179,7 +179,7 @@
 
   </div>
   <footer class="footer">
-    OpenDraft User Manual &middot; v0.14.1 &middot; Made by Proteus Technologies
+    OpenDraft User Manual &middot; v0.15.0 &middot; Made by Proteus Technologies
   </footer>
 </main>
 

--- a/user-manual/index-cards.html
+++ b/user-manual/index-cards.html
@@ -152,7 +152,7 @@
 
   </div>
   <footer class="footer">
-    OpenDraft User Manual &middot; v0.14.1 &middot; Made by Proteus Technologies
+    OpenDraft User Manual &middot; v0.15.0 &middot; Made by Proteus Technologies
   </footer>
 </main>
 

--- a/user-manual/index.html
+++ b/user-manual/index.html
@@ -170,7 +170,7 @@
       <li><strong>Collaboration UX</strong> &mdash; Password show/hide toggles in the collab login dialog and persistent display name across sessions.</li>
     </ul>
 
-    <h3>v0.14.1</h3>
+    <h3>v0.15.0</h3>
     <ul>
       <li><strong>Scene Numbering</strong> &mdash; Show, hide, and lock scene numbers in your screenplay. Essential for production scripts.</li>
       <li><strong>Custom Headers &amp; Footers</strong> &mdash; Configure page headers and footers with dynamic fields like page number, title, and date.</li>
@@ -197,7 +197,7 @@
 
   </div>
   <footer class="footer">
-    OpenDraft User Manual &middot; v0.14.1 &middot; Made by Proteus Technologies
+    OpenDraft User Manual &middot; v0.15.0 &middot; Made by Proteus Technologies
   </footer>
 </main>
 

--- a/user-manual/installation.html
+++ b/user-manual/installation.html
@@ -229,7 +229,7 @@ pip install -r backend/requirements.txt</code></pre>
 
   </div>
   <footer class="footer">
-    OpenDraft User Manual &middot; v0.14.1 &middot; Made by Proteus Technologies
+    OpenDraft User Manual &middot; v0.15.0 &middot; Made by Proteus Technologies
   </footer>
 </main>
 

--- a/user-manual/keyboard-shortcuts.html
+++ b/user-manual/keyboard-shortcuts.html
@@ -174,7 +174,7 @@
 
   </div>
   <footer class="footer">
-    OpenDraft User Manual &middot; v0.14.1 &middot; Made by Proteus Technologies
+    OpenDraft User Manual &middot; v0.15.0 &middot; Made by Proteus Technologies
   </footer>
 </main>
 

--- a/user-manual/locations.html
+++ b/user-manual/locations.html
@@ -167,7 +167,7 @@ INT. COFFEE SHOP - DAY</code></pre>
 
   </div>
   <footer class="footer">
-    OpenDraft User Manual &middot; v0.14.1 &middot; Made by Proteus Technologies
+    OpenDraft User Manual &middot; v0.15.0 &middot; Made by Proteus Technologies
   </footer>
 </main>
 

--- a/user-manual/page-setup.html
+++ b/user-manual/page-setup.html
@@ -195,7 +195,7 @@
 
   </div>
   <footer class="footer">
-    OpenDraft User Manual &middot; v0.14.1 &middot; Made by Proteus Technologies
+    OpenDraft User Manual &middot; v0.15.0 &middot; Made by Proteus Technologies
   </footer>
 </main>
 

--- a/user-manual/projects.html
+++ b/user-manual/projects.html
@@ -215,7 +215,7 @@
 
   </div>
   <footer class="footer">
-    OpenDraft User Manual &middot; v0.14.1 &middot; Made by Proteus Technologies
+    OpenDraft User Manual &middot; v0.15.0 &middot; Made by Proteus Technologies
   </footer>
 </main>
 

--- a/user-manual/revision-mode.html
+++ b/user-manual/revision-mode.html
@@ -162,7 +162,7 @@
 
   </div>
   <footer class="footer">
-    OpenDraft User Manual &middot; v0.14.1 &middot; Made by Proteus Technologies
+    OpenDraft User Manual &middot; v0.15.0 &middot; Made by Proteus Technologies
   </footer>
 </main>
 

--- a/user-manual/scene-navigator.html
+++ b/user-manual/scene-navigator.html
@@ -160,7 +160,7 @@
 
   </div>
   <footer class="footer">
-    OpenDraft User Manual &middot; v0.14.1 &middot; Made by Proteus Technologies
+    OpenDraft User Manual &middot; v0.15.0 &middot; Made by Proteus Technologies
   </footer>
 </main>
 

--- a/user-manual/script-notes.html
+++ b/user-manual/script-notes.html
@@ -166,7 +166,7 @@
 
   </div>
   <footer class="footer">
-    OpenDraft User Manual &middot; v0.14.1 &middot; Made by Proteus Technologies
+    OpenDraft User Manual &middot; v0.15.0 &middot; Made by Proteus Technologies
   </footer>
 </main>
 

--- a/user-manual/spell-check.html
+++ b/user-manual/spell-check.html
@@ -148,7 +148,7 @@
 
   </div>
   <footer class="footer">
-    OpenDraft User Manual &middot; v0.14.1 &middot; Made by Proteus Technologies
+    OpenDraft User Manual &middot; v0.15.0 &middot; Made by Proteus Technologies
   </footer>
 </main>
 

--- a/user-manual/tags.html
+++ b/user-manual/tags.html
@@ -181,7 +181,7 @@
 
   </div>
   <footer class="footer">
-    OpenDraft User Manual &middot; v0.14.1 &middot; Made by Proteus Technologies
+    OpenDraft User Manual &middot; v0.15.0 &middot; Made by Proteus Technologies
   </footer>
 </main>
 

--- a/user-manual/themes.html
+++ b/user-manual/themes.html
@@ -127,7 +127,7 @@
 
   </div>
   <footer class="footer">
-    OpenDraft User Manual &middot; v0.14.1 &middot; Made by Proteus Technologies
+    OpenDraft User Manual &middot; v0.15.0 &middot; Made by Proteus Technologies
   </footer>
 </main>
 

--- a/user-manual/version-history.html
+++ b/user-manual/version-history.html
@@ -205,7 +205,7 @@
 
   </div>
   <footer class="footer">
-    OpenDraft User Manual &middot; v0.14.1 &middot; Made by Proteus Technologies
+    OpenDraft User Manual &middot; v0.15.0 &middot; Made by Proteus Technologies
   </footer>
 </main>
 

--- a/user-manual/writing-screenplay.html
+++ b/user-manual/writing-screenplay.html
@@ -304,7 +304,7 @@
 
   </div>
   <footer class="footer">
-    OpenDraft User Manual &middot; v0.14.1 &middot; Made by Proteus Technologies
+    OpenDraft User Manual &middot; v0.15.0 &middot; Made by Proteus Technologies
   </footer>
 </main>
 


### PR DESCRIPTION
## Release v0.15.0

Version bump and download link updates. The release is already published and all builds are live.

**Safe to merge** — download links will start pointing to the new version after merge.