### PR TITLE
Fix Intel Mac workflow for manual dispatch

### DIFF
--- a/.github/workflows/build-intel-mac.yml
+++ b/.github/workflows/build-intel-mac.yml
@@ -68,7 +68,9 @@ jobs:
           fs.writeFileSync('tauri.conf.json', JSON.stringify(cfg, null, 2));
           "
 
-      - name: Build Tauri app
+      # ── Tag push: build + upload to GitHub Release ──
+      - name: Build Tauri app (release)
+        if: startsWith(github.ref, 'refs/tags/v')
         id: tauri_build
         timeout-minutes: 30
         continue-on-error: true
@@ -88,8 +90,8 @@ jobs:
           prerelease: false
           includeUpdaterJson: false
 
-      - name: Build Tauri app (retry)
-        if: steps.tauri_build.outcome == 'failure'
+      - name: Build Tauri app (release retry)
+        if: startsWith(github.ref, 'refs/tags/v') && steps.tauri_build.outcome == 'failure'
         timeout-minutes: 30
         uses: tauri-apps/tauri-action@v0
         env:
@@ -106,3 +108,21 @@ jobs:
           releaseDraft: true
           prerelease: false
           includeUpdaterJson: false
+
+      # ── Manual dispatch: build + upload as workflow artifact ──
+      - name: Build Tauri app (manual)
+        if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
+        timeout-minutes: 30
+        env:
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+        run: npx --prefix frontend tauri build
+
+      - name: Upload build artifact
+        if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
+        uses: actions/upload-artifact@v5
+        with:
+          name: OpenDraft-intel-mac
+          path: src-tauri/target/release/bundle/dmg/*.dmg


### PR DESCRIPTION
## Summary

- Fixes the Intel Mac workflow cancelling on manual dispatch (`workflow_dispatch`)
- Tag pushes (`v*`) use `tauri-action` to upload the `.dmg` to the GitHub Release
- Manual dispatch uses plain `tauri build` and uploads the `.dmg` as a workflow artifact

## What happened

The previous workflow always used `tauri-action` with `tagName: ${{ github.ref_name }}`. On manual dispatch, `ref_name` is the branch name (e.g., `main`) instead of a `v*` tag, causing the action to fail and cancel.

## Test plan

- [ ] Merge this PR
- [ ] Trigger "Run workflow" from Actions tab
- [ ] Confirm the build completes and a `.dmg` artifact appears at the bottom of the workflow run

https://claude.ai/code/session_01Nckx1WEiXwx9xQQJ3oijv8