### PR TITLE
Fix Intel Mac build: cross-compile from Apple Silicon runner

### DIFF
--- a/.github/workflows/build-intel-mac.yml
+++ b/.github/workflows/build-intel-mac.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   build-intel-mac:
-    runs-on: macos-13
+    runs-on: macos-26
     name: Build (macOS-Intel)
 
     steps:
@@ -83,6 +83,7 @@ jobs:
           APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
         with:
           tauriScript: npx --prefix frontend tauri
+          args: --target x86_64-apple-darwin
           tagName: ${{ github.ref_name }}
           releaseName: 'OpenDraft ${{ github.ref_name }}'
           releaseBody: ''
@@ -102,6 +103,7 @@ jobs:
           APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
         with:
           tauriScript: npx --prefix frontend tauri
+          args: --target x86_64-apple-darwin
           tagName: ${{ github.ref_name }}
           releaseName: 'OpenDraft ${{ github.ref_name }}'
           releaseBody: ''
@@ -118,11 +120,11 @@ jobs:
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
           APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
-        run: npx --prefix frontend tauri build
+        run: npx --prefix frontend tauri build --target x86_64-apple-darwin
 
       - name: Upload build artifact
         if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
         uses: actions/upload-artifact@v5
         with:
           name: OpenDraft-intel-mac
-          path: src-tauri/target/release/bundle/dmg/*.dmg
+          path: src-tauri/target/x86_64-apple-darwin/release/bundle/dmg/*.dmg


### PR DESCRIPTION
## Summary

- `macos-13` (Intel) runner is deprecated by GitHub — builds were getting cancelled with "configuration not supported"
- Switches to `macos-26` (Apple Silicon) runner and cross-compiles with `--target x86_64-apple-darwin`
- Fixes artifact upload path to use the target-specific output directory (`target/x86_64-apple-darwin/release/...`)

## How it works

Rust natively supports cross-compiling from `aarch64-apple-darwin` to `x86_64-apple-darwin` on macOS. The `rustup target add x86_64-apple-darwin` step (via `dtolnay/rust-toolchain`) installs the cross-compilation target, and `--target x86_64-apple-darwin` tells Tauri/Cargo to build for Intel.

## Test plan

- [ ] Merge this PR
- [ ] Trigger "Run workflow" from the Actions tab
- [ ] Confirm the build completes successfully on `macos-26`
- [ ] Download the `.dmg` artifact and verify it's an x86_64 binary (`file OpenDraft.app/Contents/MacOS/opendraft` should show `x86_64`)

https://claude.ai/code/session_01Nckx1WEiXwx9xQQJ3oijv8