### PR TITLE
Release v0.16.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,13 +149,13 @@ Get the latest version — no account required, just install and start writing. 
 
 | Platform | Download |
 |----------|----------|
-| **macOS** (Apple Silicon) | [Download .dmg](https://github.com/Proteus-Technologies-Private-Limited/OpenDraft/releases/latest/download/OpenDraft_0.16.0_aarch64.dmg) |
-| **macOS** (Intel) | [Download .dmg](https://github.com/Proteus-Technologies-Private-Limited/OpenDraft/releases/latest/download/OpenDraft_0.16.0_x86_64.dmg) |
-| **Windows** (64-bit) | [Download .exe](https://github.com/Proteus-Technologies-Private-Limited/OpenDraft/releases/latest/download/OpenDraft_0.16.0_x64-setup.exe) |
-| **Windows** (MSI) | [Download .msi](https://github.com/Proteus-Technologies-Private-Limited/OpenDraft/releases/latest/download/OpenDraft_0.16.0_x64_en-US.msi) |
-| **Linux** (Debian/Ubuntu) | [Download .deb](https://github.com/Proteus-Technologies-Private-Limited/OpenDraft/releases/latest/download/OpenDraft_0.16.0_amd64.deb) |
-| **Linux** (AppImage) | [Download .AppImage](https://github.com/Proteus-Technologies-Private-Limited/OpenDraft/releases/latest/download/OpenDraft_0.16.0_amd64.AppImage) |
-| **Linux** (RPM/Fedora) | [Download .rpm](https://github.com/Proteus-Technologies-Private-Limited/OpenDraft/releases/latest/download/OpenDraft-0.16.0-1.x86_64.rpm) |
+| **macOS** (Apple Silicon) | [Download .dmg](https://github.com/Proteus-Technologies-Private-Limited/OpenDraft/releases/latest/download/OpenDraft_0.16.1_aarch64.dmg) |
+| **macOS** (Intel) | [Download .dmg](https://github.com/Proteus-Technologies-Private-Limited/OpenDraft/releases/latest/download/OpenDraft_0.16.1_x86_64.dmg) |
+| **Windows** (64-bit) | [Download .exe](https://github.com/Proteus-Technologies-Private-Limited/OpenDraft/releases/latest/download/OpenDraft_0.16.1_x64-setup.exe) |
+| **Windows** (MSI) | [Download .msi](https://github.com/Proteus-Technologies-Private-Limited/OpenDraft/releases/latest/download/OpenDraft_0.16.1_x64_en-US.msi) |
+| **Linux** (Debian/Ubuntu) | [Download .deb](https://github.com/Proteus-Technologies-Private-Limited/OpenDraft/releases/latest/download/OpenDraft_0.16.1_amd64.deb) |
+| **Linux** (AppImage) | [Download .AppImage](https://github.com/Proteus-Technologies-Private-Limited/OpenDraft/releases/latest/download/OpenDraft_0.16.1_amd64.AppImage) |
+| **Linux** (RPM/Fedora) | [Download .rpm](https://github.com/Proteus-Technologies-Private-Limited/OpenDraft/releases/latest/download/OpenDraft-0.16.1-1.x86_64.rpm) |
 
 ### Mobile
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -25,7 +25,7 @@ async def lifespan(app: FastAPI):
 app = FastAPI(
     title="OpenDraft API",
     description="Backend API for OpenDraft screenwriting application",
-    version="0.16.0",
+    version="0.16.1",
     lifespan=lifespan,
 )
 

--- a/frontend/src/components/MenuBar.tsx
+++ b/frontend/src/components/MenuBar.tsx
@@ -1337,11 +1337,11 @@ const MenuBar: React.FC<MenuBarProps> = ({ editor, onCollaborate, onJoinCollab, 
           <div className="dialog-header">About Open Draft</div>
           <div className="dialog-body about-body">
             <div className="about-title">Open Draft</div>
-            <div className="about-version">Version 0.16.0</div>
+            <div className="about-version">Version 0.16.1</div>
             <div className="about-tagline">Free, open-source screenwriting software</div>
 
             <div className="about-whats-new">
-              <div className="about-section-title">What's New in 0.16.0</div>
+              <div className="about-section-title">What's New in 0.16.1</div>
               <ul className="about-list">
                 <li><strong>Multiple Windows</strong> — Open different files in separate windows via File &gt; New Window. Each window has independent editor state.</li>
                 <li><strong>Save Status Indicator</strong> — The status bar now shows Unsaved changes, Saving, Saved, or Save failed in real time.</li>

--- a/landing/index.html
+++ b/landing/index.html
@@ -675,17 +675,17 @@
         <p class="section-desc">Available on every major platform. Free, no account needed. Most users are writing in under 2 minutes.</p>
       </div>
       <div class="download-grid">
-        <a href="https://github.com/Proteus-Technologies-Private-Limited/OpenDraft/releases/latest/download/OpenDraft_0.16.0_aarch64.dmg" class="download-card">
+        <a href="https://github.com/Proteus-Technologies-Private-Limited/OpenDraft/releases/latest/download/OpenDraft_0.16.1_aarch64.dmg" class="download-card">
           <svg class="platform-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5"><rect x="2" y="3" width="20" height="14" rx="2"/><line x1="8" y1="21" x2="16" y2="21"/><line x1="12" y1="17" x2="12" y2="21"/></svg>
           <h3>macOS</h3>
           <p>Apple Silicon .dmg</p>
         </a>
-        <a href="https://github.com/Proteus-Technologies-Private-Limited/OpenDraft/releases/latest/download/OpenDraft_0.16.0_x64-setup.exe" class="download-card">
+        <a href="https://github.com/Proteus-Technologies-Private-Limited/OpenDraft/releases/latest/download/OpenDraft_0.16.1_x64-setup.exe" class="download-card">
           <svg class="platform-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5"><rect x="2" y="3" width="20" height="14" rx="2"/><line x1="8" y1="21" x2="16" y2="21"/><line x1="12" y1="17" x2="12" y2="21"/></svg>
           <h3>Windows</h3>
           <p>64-bit installer</p>
         </a>
-        <a href="https://github.com/Proteus-Technologies-Private-Limited/OpenDraft/releases/latest/download/OpenDraft_0.16.0_amd64.deb" class="download-card">
+        <a href="https://github.com/Proteus-Technologies-Private-Limited/OpenDraft/releases/latest/download/OpenDraft_0.16.1_amd64.deb" class="download-card">
           <svg class="platform-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5"><rect x="4" y="2" width="16" height="20" rx="2"/><line x1="12" y1="18" x2="12" y2="18.01"/></svg>
           <h3>Linux</h3>
           <p>.deb / .AppImage / .rpm</p>
@@ -697,27 +697,27 @@
           More download options
         </summary>
         <div class="download-grid" style="margin-top:16px;">
-          <a href="https://github.com/Proteus-Technologies-Private-Limited/OpenDraft/releases/latest/download/OpenDraft_0.16.0_x86_64.dmg" class="download-card">
+          <a href="https://github.com/Proteus-Technologies-Private-Limited/OpenDraft/releases/latest/download/OpenDraft_0.16.1_x86_64.dmg" class="download-card">
             <svg class="platform-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5"><rect x="2" y="3" width="20" height="14" rx="2"/><line x1="8" y1="21" x2="16" y2="21"/><line x1="12" y1="17" x2="12" y2="21"/></svg>
             <h3>macOS (Intel)</h3>
             <p>For Intel Macs running macOS 12 Monterey or newer</p>
           </a>
-          <a href="https://github.com/Proteus-Technologies-Private-Limited/OpenDraft/releases/latest/download/OpenDraft_0.16.0_x86_64-legacy.dmg" class="download-card">
+          <a href="https://github.com/Proteus-Technologies-Private-Limited/OpenDraft/releases/latest/download/OpenDraft_0.16.1_x86_64-legacy.dmg" class="download-card">
             <svg class="platform-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5"><rect x="2" y="3" width="20" height="14" rx="2"/><line x1="8" y1="21" x2="16" y2="21"/><line x1="12" y1="17" x2="12" y2="21"/></svg>
             <h3>macOS (Older Intel)</h3>
             <p>For Intel Macs running macOS 10.13 High Sierra through 11 Big Sur</p>
           </a>
-          <a href="https://github.com/Proteus-Technologies-Private-Limited/OpenDraft/releases/latest/download/OpenDraft_0.16.0_x64_en-US.msi" class="download-card">
+          <a href="https://github.com/Proteus-Technologies-Private-Limited/OpenDraft/releases/latest/download/OpenDraft_0.16.1_x64_en-US.msi" class="download-card">
             <svg class="platform-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5"><rect x="2" y="3" width="20" height="14" rx="2"/><line x1="8" y1="21" x2="16" y2="21"/><line x1="12" y1="17" x2="12" y2="21"/></svg>
             <h3>Windows (MSI)</h3>
             <p>64-bit MSI installer</p>
           </a>
-          <a href="https://github.com/Proteus-Technologies-Private-Limited/OpenDraft/releases/latest/download/OpenDraft_0.16.0_amd64.AppImage" class="download-card">
+          <a href="https://github.com/Proteus-Technologies-Private-Limited/OpenDraft/releases/latest/download/OpenDraft_0.16.1_amd64.AppImage" class="download-card">
             <svg class="platform-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5"><rect x="4" y="2" width="16" height="20" rx="2"/><line x1="12" y1="18" x2="12" y2="18.01"/></svg>
             <h3>Linux (AppImage)</h3>
             <p>Portable, no install needed</p>
           </a>
-          <a href="https://github.com/Proteus-Technologies-Private-Limited/OpenDraft/releases/latest/download/OpenDraft_0.16.0_android.apk" class="download-card">
+          <a href="https://github.com/Proteus-Technologies-Private-Limited/OpenDraft/releases/latest/download/OpenDraft_0.16.1_android.apk" class="download-card">
             <svg class="platform-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5"><rect x="5" y="2" width="14" height="20" rx="3"/><line x1="12" y1="18" x2="12" y2="18.01"/></svg>
             <h3>Android (APK)</h3>
             <p>Sideload .apk</p>

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2435,7 +2435,7 @@ checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "opendraft"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "jni",
  "ndk-context",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "opendraft"
-version = "0.16.0"
+version = "0.16.1"
 description = "OpenDraft - Professional Screenwriting Application"
 authors = ["OpenDraft"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-config-schema/schema.json",
   "productName": "OpenDraft",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "identifier": "com.proteus.opendraft",
   "build": {
     "frontendDist": "../frontend/dist",

--- a/user-manual/beat-board.html
+++ b/user-manual/beat-board.html
@@ -171,7 +171,7 @@
 
   </div>
   <footer class="footer">
-    OpenDraft User Manual &middot; v0.16.0 &middot; Made by Proteus Technologies
+    OpenDraft User Manual &middot; v0.16.1 &middot; Made by Proteus Technologies
   </footer>
 </main>
 

--- a/user-manual/characters.html
+++ b/user-manual/characters.html
@@ -257,7 +257,7 @@
 
   </div>
   <footer class="footer">
-    OpenDraft User Manual &middot; v0.16.0 &middot; Made by Proteus Technologies
+    OpenDraft User Manual &middot; v0.16.1 &middot; Made by Proteus Technologies
   </footer>
 </main>
 

--- a/user-manual/collaboration.html
+++ b/user-manual/collaboration.html
@@ -238,7 +238,7 @@
 
   </div>
   <footer class="footer">
-    OpenDraft User Manual &middot; v0.16.0 &middot; Made by Proteus Technologies
+    OpenDraft User Manual &middot; v0.16.1 &middot; Made by Proteus Technologies
   </footer>
 </main>
 

--- a/user-manual/find-replace.html
+++ b/user-manual/find-replace.html
@@ -163,7 +163,7 @@
 
   </div>
   <footer class="footer">
-    OpenDraft User Manual &middot; v0.16.0 &middot; Made by Proteus Technologies
+    OpenDraft User Manual &middot; v0.16.1 &middot; Made by Proteus Technologies
   </footer>
 </main>
 

--- a/user-manual/formatting.html
+++ b/user-manual/formatting.html
@@ -370,7 +370,7 @@
 
   </div>
   <footer class="footer">
-    OpenDraft User Manual &middot; v0.16.0 &middot; Made by Proteus Technologies
+    OpenDraft User Manual &middot; v0.16.1 &middot; Made by Proteus Technologies
   </footer>
 </main>
 

--- a/user-manual/getting-started.html
+++ b/user-manual/getting-started.html
@@ -247,7 +247,7 @@
 
   </div>
   <footer class="footer">
-    OpenDraft User Manual &middot; v0.16.0 &middot; Made by Proteus Technologies
+    OpenDraft User Manual &middot; v0.16.1 &middot; Made by Proteus Technologies
   </footer>
 </main>
 

--- a/user-manual/import-export.html
+++ b/user-manual/import-export.html
@@ -179,7 +179,7 @@
 
   </div>
   <footer class="footer">
-    OpenDraft User Manual &middot; v0.16.0 &middot; Made by Proteus Technologies
+    OpenDraft User Manual &middot; v0.16.1 &middot; Made by Proteus Technologies
   </footer>
 </main>
 

--- a/user-manual/index-cards.html
+++ b/user-manual/index-cards.html
@@ -152,7 +152,7 @@
 
   </div>
   <footer class="footer">
-    OpenDraft User Manual &middot; v0.16.0 &middot; Made by Proteus Technologies
+    OpenDraft User Manual &middot; v0.16.1 &middot; Made by Proteus Technologies
   </footer>
 </main>
 

--- a/user-manual/index.html
+++ b/user-manual/index.html
@@ -163,7 +163,7 @@
 
     <h2 id="whats-new">What's New</h2>
 
-    <h3>v0.16.0</h3>
+    <h3>v0.16.1</h3>
     <ul>
       <li><strong>Multiple Windows</strong> &mdash; Open different files in separate windows via File &gt; New Window. Each window has independent editor state.</li>
       <li><strong>Save Status Indicator</strong> &mdash; The status bar now shows Unsaved changes, Saving, Saved, or Save failed in real time.</li>
@@ -173,7 +173,7 @@
       <li><strong>Open With in New Window</strong> &mdash; Double-clicking a screenplay file while the app is running opens it in a new window.</li>
     </ul>
 
-    <h3>v0.16.0</h3>
+    <h3>v0.16.1</h3>
     <ul>
       <li><strong>iPad &amp; Touch UX</strong> &mdash; Touch-friendly comfortable mode with larger tap targets, proper iPadOS detection, and iPad keyboard dismissal fix.</li>
       <li><strong>Element Type Shortcuts</strong> &mdash; Press Cmd/Ctrl-1 through 8 to quickly switch element types (Scene Heading, Action, Character, etc.) while writing.</li>
@@ -207,7 +207,7 @@
 
   </div>
   <footer class="footer">
-    OpenDraft User Manual &middot; v0.16.0 &middot; Made by Proteus Technologies
+    OpenDraft User Manual &middot; v0.16.1 &middot; Made by Proteus Technologies
   </footer>
 </main>
 

--- a/user-manual/installation.html
+++ b/user-manual/installation.html
@@ -229,7 +229,7 @@ pip install -r backend/requirements.txt</code></pre>
 
   </div>
   <footer class="footer">
-    OpenDraft User Manual &middot; v0.16.0 &middot; Made by Proteus Technologies
+    OpenDraft User Manual &middot; v0.16.1 &middot; Made by Proteus Technologies
   </footer>
 </main>
 

--- a/user-manual/keyboard-shortcuts.html
+++ b/user-manual/keyboard-shortcuts.html
@@ -174,7 +174,7 @@
 
   </div>
   <footer class="footer">
-    OpenDraft User Manual &middot; v0.16.0 &middot; Made by Proteus Technologies
+    OpenDraft User Manual &middot; v0.16.1 &middot; Made by Proteus Technologies
   </footer>
 </main>
 

--- a/user-manual/locations.html
+++ b/user-manual/locations.html
@@ -167,7 +167,7 @@ INT. COFFEE SHOP - DAY</code></pre>
 
   </div>
   <footer class="footer">
-    OpenDraft User Manual &middot; v0.16.0 &middot; Made by Proteus Technologies
+    OpenDraft User Manual &middot; v0.16.1 &middot; Made by Proteus Technologies
   </footer>
 </main>
 

--- a/user-manual/page-setup.html
+++ b/user-manual/page-setup.html
@@ -195,7 +195,7 @@
 
   </div>
   <footer class="footer">
-    OpenDraft User Manual &middot; v0.16.0 &middot; Made by Proteus Technologies
+    OpenDraft User Manual &middot; v0.16.1 &middot; Made by Proteus Technologies
   </footer>
 </main>
 

--- a/user-manual/projects.html
+++ b/user-manual/projects.html
@@ -215,7 +215,7 @@
 
   </div>
   <footer class="footer">
-    OpenDraft User Manual &middot; v0.16.0 &middot; Made by Proteus Technologies
+    OpenDraft User Manual &middot; v0.16.1 &middot; Made by Proteus Technologies
   </footer>
 </main>
 

--- a/user-manual/revision-mode.html
+++ b/user-manual/revision-mode.html
@@ -162,7 +162,7 @@
 
   </div>
   <footer class="footer">
-    OpenDraft User Manual &middot; v0.16.0 &middot; Made by Proteus Technologies
+    OpenDraft User Manual &middot; v0.16.1 &middot; Made by Proteus Technologies
   </footer>
 </main>
 

--- a/user-manual/scene-navigator.html
+++ b/user-manual/scene-navigator.html
@@ -160,7 +160,7 @@
 
   </div>
   <footer class="footer">
-    OpenDraft User Manual &middot; v0.16.0 &middot; Made by Proteus Technologies
+    OpenDraft User Manual &middot; v0.16.1 &middot; Made by Proteus Technologies
   </footer>
 </main>
 

--- a/user-manual/script-notes.html
+++ b/user-manual/script-notes.html
@@ -166,7 +166,7 @@
 
   </div>
   <footer class="footer">
-    OpenDraft User Manual &middot; v0.16.0 &middot; Made by Proteus Technologies
+    OpenDraft User Manual &middot; v0.16.1 &middot; Made by Proteus Technologies
   </footer>
 </main>
 

--- a/user-manual/search.js
+++ b/user-manual/search.js
@@ -11,7 +11,7 @@
     // Index / Home
     { page: 'Home', title: 'Welcome to OpenDraft', section: '', text: 'Free open-source screenwriting application. Professional screenplay editing with real-time collaboration. No subscription required.', url: 'index.html' },
     { page: 'Home', title: 'Quick Start', section: 'Quick Start', text: 'Install OpenDraft download desktop app. Create a project. Start writing new script. Save your work Cmd S check in version checkpoint.', url: 'index.html#quick-start' },
-    { page: 'Home', title: "What's New in v0.16.0", section: "What's New", text: 'Multiple windows open different files new window. Save status indicator unsaved saving saved failed. Save failure recovery retry save as export backup. Collaboration status activity log connecting synced reconnecting joins leaves. File drag and drop fix desktop. Open with new window file association.', url: 'index.html#whats-new' },
+    { page: 'Home', title: "What's New in v0.16.1", section: "What's New", text: 'Multiple windows open different files new window. Save status indicator unsaved saving saved failed. Save failure recovery retry save as export backup. Collaboration status activity log connecting synced reconnecting joins leaves. File drag and drop fix desktop. Open with new window file association.', url: 'index.html#whats-new' },
 
     // Getting Started
     { page: 'Getting Started', title: 'Getting Started', section: '', text: 'Write your first screenplay in 5 minutes. Beginner guide walkthrough basics. New to screenwriting software.', url: 'getting-started.html' },

--- a/user-manual/spell-check.html
+++ b/user-manual/spell-check.html
@@ -148,7 +148,7 @@
 
   </div>
   <footer class="footer">
-    OpenDraft User Manual &middot; v0.16.0 &middot; Made by Proteus Technologies
+    OpenDraft User Manual &middot; v0.16.1 &middot; Made by Proteus Technologies
   </footer>
 </main>
 

--- a/user-manual/tags.html
+++ b/user-manual/tags.html
@@ -181,7 +181,7 @@
 
   </div>
   <footer class="footer">
-    OpenDraft User Manual &middot; v0.16.0 &middot; Made by Proteus Technologies
+    OpenDraft User Manual &middot; v0.16.1 &middot; Made by Proteus Technologies
   </footer>
 </main>
 

--- a/user-manual/themes.html
+++ b/user-manual/themes.html
@@ -127,7 +127,7 @@
 
   </div>
   <footer class="footer">
-    OpenDraft User Manual &middot; v0.16.0 &middot; Made by Proteus Technologies
+    OpenDraft User Manual &middot; v0.16.1 &middot; Made by Proteus Technologies
   </footer>
 </main>
 

--- a/user-manual/version-history.html
+++ b/user-manual/version-history.html
@@ -205,7 +205,7 @@
 
   </div>
   <footer class="footer">
-    OpenDraft User Manual &middot; v0.16.0 &middot; Made by Proteus Technologies
+    OpenDraft User Manual &middot; v0.16.1 &middot; Made by Proteus Technologies
   </footer>
 </main>
 

--- a/user-manual/writing-screenplay.html
+++ b/user-manual/writing-screenplay.html
@@ -304,7 +304,7 @@
 
   </div>
   <footer class="footer">
-    OpenDraft User Manual &middot; v0.16.0 &middot; Made by Proteus Technologies
+    OpenDraft User Manual &middot; v0.16.1 &middot; Made by Proteus Technologies
   </footer>
 </main>
 


### PR DESCRIPTION
## Release v0.16.1

Version bump and download link updates. The release is already published and all builds are live.

**Safe to merge** — download links will start pointing to the new version after merge.