### PR TITLE
Release v0.17.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,13 +149,13 @@ Get the latest version — no account required, just install and start writing. 
 
 | Platform | Download |
 |----------|----------|
-| **macOS** (Apple Silicon) | [Download .dmg](https://github.com/Proteus-Technologies-Private-Limited/OpenDraft/releases/latest/download/OpenDraft_0.17.0_aarch64.dmg) |
-| **macOS** (Intel) | [Download .dmg](https://github.com/Proteus-Technologies-Private-Limited/OpenDraft/releases/latest/download/OpenDraft_0.17.0_x64.dmg) |
-| **Windows** (64-bit) | [Download .exe](https://github.com/Proteus-Technologies-Private-Limited/OpenDraft/releases/latest/download/OpenDraft_0.17.0_x64-setup.exe) |
-| **Windows** (MSI) | [Download .msi](https://github.com/Proteus-Technologies-Private-Limited/OpenDraft/releases/latest/download/OpenDraft_0.17.0_x64_en-US.msi) |
-| **Linux** (Debian/Ubuntu) | [Download .deb](https://github.com/Proteus-Technologies-Private-Limited/OpenDraft/releases/latest/download/OpenDraft_0.17.0_amd64.deb) |
-| **Linux** (AppImage) | [Download .AppImage](https://github.com/Proteus-Technologies-Private-Limited/OpenDraft/releases/latest/download/OpenDraft_0.17.0_amd64.AppImage) |
-| **Linux** (RPM/Fedora) | [Download .rpm](https://github.com/Proteus-Technologies-Private-Limited/OpenDraft/releases/latest/download/OpenDraft-0.17.0-1.x86_64.rpm) |
+| **macOS** (Apple Silicon) | [Download .dmg](https://github.com/Proteus-Technologies-Private-Limited/OpenDraft/releases/latest/download/OpenDraft_0.17.1_aarch64.dmg) |
+| **macOS** (Intel) | [Download .dmg](https://github.com/Proteus-Technologies-Private-Limited/OpenDraft/releases/latest/download/OpenDraft_0.17.1_x64.dmg) |
+| **Windows** (64-bit) | [Download .exe](https://github.com/Proteus-Technologies-Private-Limited/OpenDraft/releases/latest/download/OpenDraft_0.17.1_x64-setup.exe) |
+| **Windows** (MSI) | [Download .msi](https://github.com/Proteus-Technologies-Private-Limited/OpenDraft/releases/latest/download/OpenDraft_0.17.1_x64_en-US.msi) |
+| **Linux** (Debian/Ubuntu) | [Download .deb](https://github.com/Proteus-Technologies-Private-Limited/OpenDraft/releases/latest/download/OpenDraft_0.17.1_amd64.deb) |
+| **Linux** (AppImage) | [Download .AppImage](https://github.com/Proteus-Technologies-Private-Limited/OpenDraft/releases/latest/download/OpenDraft_0.17.1_amd64.AppImage) |
+| **Linux** (RPM/Fedora) | [Download .rpm](https://github.com/Proteus-Technologies-Private-Limited/OpenDraft/releases/latest/download/OpenDraft-0.17.1-1.x86_64.rpm) |
 
 ### Mobile
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -46,7 +46,7 @@ async def lifespan(app: FastAPI):
 app = FastAPI(
     title="OpenDraft API",
     description="Backend API for OpenDraft screenwriting application",
-    version="0.17.0",
+    version="0.17.1",
     lifespan=lifespan,
 )
 

--- a/frontend/src/components/MenuBar.tsx
+++ b/frontend/src/components/MenuBar.tsx
@@ -1619,11 +1619,11 @@ const MenuBar: React.FC<MenuBarProps> = ({ editor, onCollaborate, onJoinCollab, 
           <div className="dialog-header">About Open Draft</div>
           <div className="dialog-body about-body">
             <div className="about-title">Open Draft</div>
-            <div className="about-version">Version 0.17.0</div>
+            <div className="about-version">Version 0.17.1</div>
             <div className="about-tagline">Free, open-source screenwriting software</div>
 
             <div className="about-whats-new">
-              <div className="about-section-title">What's New in 0.17.0</div>
+              <div className="about-section-title">What's New in 0.17.1</div>
               <ul className="about-list">
                 <li><strong>Treatment Documents</strong> — Write a 20–25 page prose treatment alongside your screenplay. Use "+ New Document" in a project to open the manuscript-format editor.</li>
                 <li><strong>Location Database</strong> — Sidebar panel for managing screenplay locations: list / detail / edit, auto-discovery from scene headings, aliases, and rename-in-scene-headings.</li>

--- a/landing/index.html
+++ b/landing/index.html
@@ -677,17 +677,17 @@
         <p class="section-desc">Available on every major platform. Free, no account needed. Most users are writing in under 2 minutes.</p>
       </div>
       <div class="download-grid">
-        <a href="https://github.com/Proteus-Technologies-Private-Limited/OpenDraft/releases/latest/download/OpenDraft_0.17.0_aarch64.dmg" class="download-card">
+        <a href="https://github.com/Proteus-Technologies-Private-Limited/OpenDraft/releases/latest/download/OpenDraft_0.17.1_aarch64.dmg" class="download-card">
           <svg class="platform-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5"><rect x="2" y="3" width="20" height="14" rx="2"/><line x1="8" y1="21" x2="16" y2="21"/><line x1="12" y1="17" x2="12" y2="21"/></svg>
           <h3>macOS</h3>
           <p>Apple Silicon .dmg</p>
         </a>
-        <a href="https://github.com/Proteus-Technologies-Private-Limited/OpenDraft/releases/latest/download/OpenDraft_0.17.0_x64-setup.exe" class="download-card">
+        <a href="https://github.com/Proteus-Technologies-Private-Limited/OpenDraft/releases/latest/download/OpenDraft_0.17.1_x64-setup.exe" class="download-card">
           <svg class="platform-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5"><rect x="2" y="3" width="20" height="14" rx="2"/><line x1="8" y1="21" x2="16" y2="21"/><line x1="12" y1="17" x2="12" y2="21"/></svg>
           <h3>Windows</h3>
           <p>64-bit installer</p>
         </a>
-        <a href="https://github.com/Proteus-Technologies-Private-Limited/OpenDraft/releases/latest/download/OpenDraft_0.17.0_amd64.deb" class="download-card">
+        <a href="https://github.com/Proteus-Technologies-Private-Limited/OpenDraft/releases/latest/download/OpenDraft_0.17.1_amd64.deb" class="download-card">
           <svg class="platform-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5"><rect x="4" y="2" width="16" height="20" rx="2"/><line x1="12" y1="18" x2="12" y2="18.01"/></svg>
           <h3>Linux</h3>
           <p>.deb / .AppImage / .rpm</p>
@@ -699,27 +699,27 @@
           More download options
         </summary>
         <div class="download-grid" style="margin-top:16px;">
-          <a href="https://github.com/Proteus-Technologies-Private-Limited/OpenDraft/releases/latest/download/OpenDraft_0.17.0_x64.dmg" class="download-card">
+          <a href="https://github.com/Proteus-Technologies-Private-Limited/OpenDraft/releases/latest/download/OpenDraft_0.17.1_x64.dmg" class="download-card">
             <svg class="platform-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5"><rect x="2" y="3" width="20" height="14" rx="2"/><line x1="8" y1="21" x2="16" y2="21"/><line x1="12" y1="17" x2="12" y2="21"/></svg>
             <h3>macOS (Intel)</h3>
             <p>For Intel Macs running macOS 12 Monterey or newer</p>
           </a>
-          <a href="https://github.com/Proteus-Technologies-Private-Limited/OpenDraft/releases/latest/download/OpenDraft_0.17.0_x86_64-legacy.dmg" class="download-card">
+          <a href="https://github.com/Proteus-Technologies-Private-Limited/OpenDraft/releases/latest/download/OpenDraft_0.17.1_x86_64-legacy.dmg" class="download-card">
             <svg class="platform-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5"><rect x="2" y="3" width="20" height="14" rx="2"/><line x1="8" y1="21" x2="16" y2="21"/><line x1="12" y1="17" x2="12" y2="21"/></svg>
             <h3>macOS (Older Intel)</h3>
             <p>For Intel Macs running macOS 10.13 High Sierra through 11 Big Sur</p>
           </a>
-          <a href="https://github.com/Proteus-Technologies-Private-Limited/OpenDraft/releases/latest/download/OpenDraft_0.17.0_x64_en-US.msi" class="download-card">
+          <a href="https://github.com/Proteus-Technologies-Private-Limited/OpenDraft/releases/latest/download/OpenDraft_0.17.1_x64_en-US.msi" class="download-card">
             <svg class="platform-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5"><rect x="2" y="3" width="20" height="14" rx="2"/><line x1="8" y1="21" x2="16" y2="21"/><line x1="12" y1="17" x2="12" y2="21"/></svg>
             <h3>Windows (MSI)</h3>
             <p>64-bit MSI installer</p>
           </a>
-          <a href="https://github.com/Proteus-Technologies-Private-Limited/OpenDraft/releases/latest/download/OpenDraft_0.17.0_amd64.AppImage" class="download-card">
+          <a href="https://github.com/Proteus-Technologies-Private-Limited/OpenDraft/releases/latest/download/OpenDraft_0.17.1_amd64.AppImage" class="download-card">
             <svg class="platform-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5"><rect x="4" y="2" width="16" height="20" rx="2"/><line x1="12" y1="18" x2="12" y2="18.01"/></svg>
             <h3>Linux (AppImage)</h3>
             <p>Portable, no install needed</p>
           </a>
-          <a href="https://github.com/Proteus-Technologies-Private-Limited/OpenDraft/releases/latest/download/OpenDraft_0.17.0_android.apk" class="download-card">
+          <a href="https://github.com/Proteus-Technologies-Private-Limited/OpenDraft/releases/latest/download/OpenDraft_0.17.1_android.apk" class="download-card">
             <svg class="platform-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5"><rect x="5" y="2" width="14" height="20" rx="3"/><line x1="12" y1="18" x2="12" y2="18.01"/></svg>
             <h3>Android (APK)</h3>
             <p>Sideload .apk</p>

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -565,7 +565,7 @@ dependencies = [
  "cssparser-macros",
  "dtoa-short",
  "itoa",
- "phf 0.13.1",
+ "phf",
  "smallvec",
 ]
 
@@ -1769,16 +1769,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
-name = "iri-string"
-version = "0.7.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
-dependencies = [
- "memchr",
- "serde",
-]
-
-[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2414,7 +2404,7 @@ checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "opendraft"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "jni",
  "ndk-context",
@@ -2506,22 +2496,12 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "phf"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
-dependencies = [
- "phf_macros 0.11.3",
- "phf_shared 0.11.3",
-]
-
-[[package]]
-name = "phf"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
 dependencies = [
- "phf_macros 0.13.1",
- "phf_shared 0.13.1",
+ "phf_macros",
+ "phf_shared",
  "serde",
 ]
 
@@ -2531,18 +2511,8 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49aa7f9d80421bca176ca8dbfebe668cc7a2684708594ec9f3c0db0805d5d6e1"
 dependencies = [
- "phf_generator 0.13.1",
- "phf_shared 0.13.1",
-]
-
-[[package]]
-name = "phf_generator"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
-dependencies = [
- "phf_shared 0.11.3",
- "rand 0.8.6",
+ "phf_generator",
+ "phf_shared",
 ]
 
 [[package]]
@@ -2552,20 +2522,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
 dependencies = [
  "fastrand",
- "phf_shared 0.13.1",
-]
-
-[[package]]
-name = "phf_macros"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
-dependencies = [
- "phf_generator 0.11.3",
- "phf_shared 0.11.3",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
+ "phf_shared",
 ]
 
 [[package]]
@@ -2574,20 +2531,11 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812f032b54b1e759ccd5f8b6677695d5268c588701effba24601f6932f8269ef"
 dependencies = [
- "phf_generator 0.13.1",
- "phf_shared 0.13.1",
+ "phf_generator",
+ "phf_shared",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
-]
-
-[[package]]
-name = "phf_shared"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
-dependencies = [
- "siphasher",
 ]
 
 [[package]]
@@ -3363,7 +3311,7 @@ dependencies = [
  "derive_more",
  "log",
  "new_debug_unreachable",
- "phf 0.13.1",
+ "phf",
  "phf_codegen",
  "precomputed-hash",
  "rustc-hash",
@@ -3911,7 +3859,7 @@ checksum = "a18596f8c785a729f2819c0f6a7eae6ebeebdfffbfe4214ae6b087f690e31901"
 dependencies = [
  "new_debug_unreachable",
  "parking_lot",
- "phf_shared 0.13.1",
+ "phf_shared",
  "precomputed-hash",
 ]
 
@@ -3921,8 +3869,8 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "585635e46db231059f76c5849798146164652513eb9e8ab2685939dd90f29b69"
 dependencies = [
- "phf_generator 0.13.1",
- "phf_shared 0.13.1",
+ "phf_generator",
+ "phf_shared",
  "proc-macro2",
  "quote",
 ]
@@ -4081,9 +4029,9 @@ checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
 
 [[package]]
 name = "tauri"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d059f2527558d9dba6f186dec4772610e1aecfd3f94002397613e7e648752b66"
+checksum = "b93bd86d231f0a8138f11a02a584769fe4b703dc36ae133d783228dbc4801405"
 dependencies = [
  "anyhow",
  "bytes",
@@ -4132,9 +4080,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-build"
-version = "2.6.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be9aa8c59a894f76c29a002501c589de5eb4987a5913d62a6e0a47f320901988"
+checksum = "3a318b234cc2dea65f575467bafcfb76286bce228ebc3778e337d61d03213007"
 dependencies = [
  "anyhow",
  "cargo_toml",
@@ -4153,9 +4101,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-codegen"
-version = "2.6.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3e4e8230d565106aa19dfbaa01a7ed01abf78047fe0577a83377224bd1bf20e"
+checksum = "6bd11644962add2549a60b7e7c6800f17d7020156e02f516021d8103e80cc528"
 dependencies = [
  "base64 0.22.1",
  "brotli",
@@ -4180,9 +4128,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-macros"
-version = "2.6.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc8de2cddbbc33dbdf4c84f170121886595efdbcc9cb4b3d76342b79d082cedc"
+checksum = "fed9d3742a37a355d2e47c9af924e9fbc112abb76f9835d35d4780e318419502"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -4194,9 +4142,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-plugin"
-version = "2.6.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8d5f58bfd0cdcfdbc0a68dc08b354eea2afc551b421de91b07b69e0dd769d57"
+checksum = "eefb2c18e8a605c23edb48fc56bb77381199e1a1e7f6ff0c9b970afe7b3cb8ee"
 dependencies = [
  "anyhow",
  "glob",
@@ -4273,9 +4221,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-runtime"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e42bbcb76237351fbaa02f08d808c537dc12eb5a6eabbf3e517b50056334d95"
+checksum = "8fef478ba1d2ac21c2d528740b24d0cb315e1e8b1111aae53fafac34804371fc"
 dependencies = [
  "cookie",
  "dpi",
@@ -4298,9 +4246,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-runtime-wry"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cadb13dad0c681e1e0a2c49ae488f0e2906ded3d57e7a0017f4aaf46e387117"
+checksum = "a3989df2ae1c476404fe0a2e8ffc4cfbde97e51efd613c2bb5355fbc9ab52cf0"
 dependencies = [
  "gtk",
  "http",
@@ -4324,9 +4272,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-utils"
-version = "2.9.0"
+version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55f61d2bf7188fbcf2b0ed095b67a6bc498f713c939314bb19eb700118a573b7"
+checksum = "d57200389a2f82b4b0a40ae29ca19b6978116e8f4d4e974c3234ce40c0ffbdec"
 dependencies = [
  "anyhow",
  "brotli",
@@ -4340,7 +4288,7 @@ dependencies = [
  "json-patch",
  "log",
  "memchr",
- "phf 0.11.3",
+ "phf",
  "plist",
  "proc-macro2",
  "quote",
@@ -4662,20 +4610,20 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.8"
+version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+checksum = "a28f0d049ccfaa566e14e9663d304d8577427b368cb4710a20528690287a738b"
 dependencies = [
  "bitflags 2.11.1",
  "bytes",
  "futures-util",
  "http",
  "http-body",
- "iri-string",
  "pin-project-lite",
  "tower",
  "tower-layer",
  "tower-service",
+ "url",
 ]
 
 [[package]]
@@ -5113,7 +5061,7 @@ version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7cff6eef815df1834fd250e3a2ff436044d82a9f1bc1980ca1dbdf07effc538"
 dependencies = [
- "phf 0.13.1",
+ "phf",
  "phf_codegen",
  "string_cache",
  "string_cache_codegen",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "opendraft"
-version = "0.17.0"
+version = "0.17.1"
 description = "OpenDraft - Professional Screenwriting Application"
 authors = ["OpenDraft"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-config-schema/schema.json",
   "productName": "OpenDraft",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "identifier": "com.proteus.opendraft",
   "build": {
     "frontendDist": "../frontend/dist",

--- a/user-manual/beat-board.html
+++ b/user-manual/beat-board.html
@@ -176,7 +176,7 @@
 
   </div>
   <footer class="footer">
-    OpenDraft User Manual &middot; v0.17.0 &middot; Made by Proteus Technologies
+    OpenDraft User Manual &middot; v0.17.1 &middot; Made by Proteus Technologies
   </footer>
 </main>
 

--- a/user-manual/characters.html
+++ b/user-manual/characters.html
@@ -346,7 +346,7 @@
 
   </div>
   <footer class="footer">
-    OpenDraft User Manual &middot; v0.17.0 &middot; Made by Proteus Technologies
+    OpenDraft User Manual &middot; v0.17.1 &middot; Made by Proteus Technologies
   </footer>
 </main>
 

--- a/user-manual/collaboration.html
+++ b/user-manual/collaboration.html
@@ -243,7 +243,7 @@
 
   </div>
   <footer class="footer">
-    OpenDraft User Manual &middot; v0.17.0 &middot; Made by Proteus Technologies
+    OpenDraft User Manual &middot; v0.17.1 &middot; Made by Proteus Technologies
   </footer>
 </main>
 

--- a/user-manual/find-replace.html
+++ b/user-manual/find-replace.html
@@ -168,7 +168,7 @@
 
   </div>
   <footer class="footer">
-    OpenDraft User Manual &middot; v0.17.0 &middot; Made by Proteus Technologies
+    OpenDraft User Manual &middot; v0.17.1 &middot; Made by Proteus Technologies
   </footer>
 </main>
 

--- a/user-manual/formatting.html
+++ b/user-manual/formatting.html
@@ -375,7 +375,7 @@
 
   </div>
   <footer class="footer">
-    OpenDraft User Manual &middot; v0.17.0 &middot; Made by Proteus Technologies
+    OpenDraft User Manual &middot; v0.17.1 &middot; Made by Proteus Technologies
   </footer>
 </main>
 

--- a/user-manual/getting-started.html
+++ b/user-manual/getting-started.html
@@ -252,7 +252,7 @@
 
   </div>
   <footer class="footer">
-    OpenDraft User Manual &middot; v0.17.0 &middot; Made by Proteus Technologies
+    OpenDraft User Manual &middot; v0.17.1 &middot; Made by Proteus Technologies
   </footer>
 </main>
 

--- a/user-manual/import-export.html
+++ b/user-manual/import-export.html
@@ -184,7 +184,7 @@
 
   </div>
   <footer class="footer">
-    OpenDraft User Manual &middot; v0.17.0 &middot; Made by Proteus Technologies
+    OpenDraft User Manual &middot; v0.17.1 &middot; Made by Proteus Technologies
   </footer>
 </main>
 

--- a/user-manual/index-cards.html
+++ b/user-manual/index-cards.html
@@ -157,7 +157,7 @@
 
   </div>
   <footer class="footer">
-    OpenDraft User Manual &middot; v0.17.0 &middot; Made by Proteus Technologies
+    OpenDraft User Manual &middot; v0.17.1 &middot; Made by Proteus Technologies
   </footer>
 </main>
 

--- a/user-manual/index.html
+++ b/user-manual/index.html
@@ -168,7 +168,7 @@
 
     <h2 id="whats-new">What's New</h2>
 
-    <h3>v0.17.0</h3>
+    <h3>v0.17.1</h3>
     <ul>
       <li><strong>Treatment Documents</strong> &mdash; Write a 20&ndash;25 page prose treatment alongside your screenplay. Use "+ New Document" in a project to open the manuscript-format editor (Times New Roman, double-spaced, 1-inch margins).</li>
       <li><strong>Location Database</strong> &mdash; Right-sidebar panel for managing screenplay locations: list, detail, and edit views; auto-discovery from scene headings; alias support; and rename-in-scene-headings.</li>
@@ -187,7 +187,7 @@
       <li><strong>Save Reliability Fixes</strong> &mdash; Manual save (Cmd+S) preserves character relationships and metadata; auto-save race on script switch fixed; metadata flushes to backend within 2s; light-theme button visibility fix.</li>
     </ul>
 
-    <h3>v0.17.0</h3>
+    <h3>v0.17.1</h3>
     <ul>
       <li><strong>Multiple Windows</strong> &mdash; Open different files in separate windows via File &gt; New Window. Each window has independent editor state.</li>
       <li><strong>Save Status Indicator</strong> &mdash; The status bar now shows Unsaved changes, Saving, Saved, or Save failed in real time.</li>
@@ -231,7 +231,7 @@
 
   </div>
   <footer class="footer">
-    OpenDraft User Manual &middot; v0.17.0 &middot; Made by Proteus Technologies
+    OpenDraft User Manual &middot; v0.17.1 &middot; Made by Proteus Technologies
   </footer>
 </main>
 

--- a/user-manual/installation.html
+++ b/user-manual/installation.html
@@ -234,7 +234,7 @@ pip install -r backend/requirements.txt</code></pre>
 
   </div>
   <footer class="footer">
-    OpenDraft User Manual &middot; v0.17.0 &middot; Made by Proteus Technologies
+    OpenDraft User Manual &middot; v0.17.1 &middot; Made by Proteus Technologies
   </footer>
 </main>
 

--- a/user-manual/keyboard-shortcuts.html
+++ b/user-manual/keyboard-shortcuts.html
@@ -179,7 +179,7 @@
 
   </div>
   <footer class="footer">
-    OpenDraft User Manual &middot; v0.17.0 &middot; Made by Proteus Technologies
+    OpenDraft User Manual &middot; v0.17.1 &middot; Made by Proteus Technologies
   </footer>
 </main>
 

--- a/user-manual/locations.html
+++ b/user-manual/locations.html
@@ -172,7 +172,7 @@ INT. COFFEE SHOP - DAY</code></pre>
 
   </div>
   <footer class="footer">
-    OpenDraft User Manual &middot; v0.17.0 &middot; Made by Proteus Technologies
+    OpenDraft User Manual &middot; v0.17.1 &middot; Made by Proteus Technologies
   </footer>
 </main>
 

--- a/user-manual/page-setup.html
+++ b/user-manual/page-setup.html
@@ -200,7 +200,7 @@
 
   </div>
   <footer class="footer">
-    OpenDraft User Manual &middot; v0.17.0 &middot; Made by Proteus Technologies
+    OpenDraft User Manual &middot; v0.17.1 &middot; Made by Proteus Technologies
   </footer>
 </main>
 

--- a/user-manual/projects.html
+++ b/user-manual/projects.html
@@ -261,7 +261,7 @@
 
   </div>
   <footer class="footer">
-    OpenDraft User Manual &middot; v0.17.0 &middot; Made by Proteus Technologies
+    OpenDraft User Manual &middot; v0.17.1 &middot; Made by Proteus Technologies
   </footer>
 </main>
 

--- a/user-manual/revision-mode.html
+++ b/user-manual/revision-mode.html
@@ -167,7 +167,7 @@
 
   </div>
   <footer class="footer">
-    OpenDraft User Manual &middot; v0.17.0 &middot; Made by Proteus Technologies
+    OpenDraft User Manual &middot; v0.17.1 &middot; Made by Proteus Technologies
   </footer>
 </main>
 

--- a/user-manual/scene-navigator.html
+++ b/user-manual/scene-navigator.html
@@ -165,7 +165,7 @@
 
   </div>
   <footer class="footer">
-    OpenDraft User Manual &middot; v0.17.0 &middot; Made by Proteus Technologies
+    OpenDraft User Manual &middot; v0.17.1 &middot; Made by Proteus Technologies
   </footer>
 </main>
 

--- a/user-manual/script-notes.html
+++ b/user-manual/script-notes.html
@@ -171,7 +171,7 @@
 
   </div>
   <footer class="footer">
-    OpenDraft User Manual &middot; v0.17.0 &middot; Made by Proteus Technologies
+    OpenDraft User Manual &middot; v0.17.1 &middot; Made by Proteus Technologies
   </footer>
 </main>
 

--- a/user-manual/script-statistics.html
+++ b/user-manual/script-statistics.html
@@ -272,7 +272,7 @@
 
   </div>
   <footer class="footer">
-    OpenDraft User Manual &middot; v0.17.0 &middot; Made by Proteus Technologies
+    OpenDraft User Manual &middot; v0.17.1 &middot; Made by Proteus Technologies
   </footer>
 </main>
 

--- a/user-manual/search.js
+++ b/user-manual/search.js
@@ -11,7 +11,7 @@
     // Index / Home
     { page: 'Home', title: 'Welcome to OpenDraft', section: '', text: 'Free open-source screenwriting application. Professional screenplay editing with real-time collaboration. No subscription required.', url: 'index.html' },
     { page: 'Home', title: 'Quick Start', section: 'Quick Start', text: 'Install OpenDraft download desktop app. Create a project. Start writing new script. Save your work Cmd S check in version checkpoint.', url: 'index.html#quick-start' },
-    { page: 'Home', title: "What's New in v0.17.0", section: "What's New", text: 'Multiple windows open different files new window. Save status indicator unsaved saving saved failed. Save failure recovery retry save as export backup. Collaboration status activity log connecting synced reconnecting joins leaves. File drag and drop fix desktop. Open with new window file association.', url: 'index.html#whats-new' },
+    { page: 'Home', title: "What's New in v0.17.1", section: "What's New", text: 'Multiple windows open different files new window. Save status indicator unsaved saving saved failed. Save failure recovery retry save as export backup. Collaboration status activity log connecting synced reconnecting joins leaves. File drag and drop fix desktop. Open with new window file association.', url: 'index.html#whats-new' },
 
     // Getting Started
     { page: 'Getting Started', title: 'Getting Started', section: '', text: 'Write your first screenplay in 5 minutes. Beginner guide walkthrough basics. New to screenwriting software.', url: 'getting-started.html' },

--- a/user-manual/spell-check.html
+++ b/user-manual/spell-check.html
@@ -153,7 +153,7 @@
 
   </div>
   <footer class="footer">
-    OpenDraft User Manual &middot; v0.17.0 &middot; Made by Proteus Technologies
+    OpenDraft User Manual &middot; v0.17.1 &middot; Made by Proteus Technologies
   </footer>
 </main>
 

--- a/user-manual/tags.html
+++ b/user-manual/tags.html
@@ -186,7 +186,7 @@
 
   </div>
   <footer class="footer">
-    OpenDraft User Manual &middot; v0.17.0 &middot; Made by Proteus Technologies
+    OpenDraft User Manual &middot; v0.17.1 &middot; Made by Proteus Technologies
   </footer>
 </main>
 

--- a/user-manual/themes.html
+++ b/user-manual/themes.html
@@ -132,7 +132,7 @@
 
   </div>
   <footer class="footer">
-    OpenDraft User Manual &middot; v0.17.0 &middot; Made by Proteus Technologies
+    OpenDraft User Manual &middot; v0.17.1 &middot; Made by Proteus Technologies
   </footer>
 </main>
 

--- a/user-manual/title-page.html
+++ b/user-manual/title-page.html
@@ -177,7 +177,7 @@
 
   </div>
   <footer class="footer">
-    OpenDraft User Manual &middot; v0.17.0 &middot; Made by Proteus Technologies
+    OpenDraft User Manual &middot; v0.17.1 &middot; Made by Proteus Technologies
   </footer>
 </main>
 

--- a/user-manual/version-history.html
+++ b/user-manual/version-history.html
@@ -210,7 +210,7 @@
 
   </div>
   <footer class="footer">
-    OpenDraft User Manual &middot; v0.17.0 &middot; Made by Proteus Technologies
+    OpenDraft User Manual &middot; v0.17.1 &middot; Made by Proteus Technologies
   </footer>
 </main>
 

--- a/user-manual/writing-screenplay.html
+++ b/user-manual/writing-screenplay.html
@@ -309,7 +309,7 @@
 
   </div>
   <footer class="footer">
-    OpenDraft User Manual &middot; v0.17.0 &middot; Made by Proteus Technologies
+    OpenDraft User Manual &middot; v0.17.1 &middot; Made by Proteus Technologies
   </footer>
 </main>
 


### PR DESCRIPTION
## Release v0.17.1

Version bump and download link updates. The release is already published and all builds are live.

**Safe to merge** — download links will start pointing to the new version after merge.