### PR TITLE
Release v0.17.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,13 +149,13 @@ Get the latest version — no account required, just install and start writing. 
 
 | Platform | Download |
 |----------|----------|
-| **macOS** (Apple Silicon) | [Download .dmg](https://github.com/Proteus-Technologies-Private-Limited/OpenDraft/releases/latest/download/OpenDraft_0.17.2_aarch64.dmg) |
-| **macOS** (Intel) | [Download .dmg](https://github.com/Proteus-Technologies-Private-Limited/OpenDraft/releases/latest/download/OpenDraft_0.17.2_x64.dmg) |
-| **Windows** (64-bit) | [Download .exe](https://github.com/Proteus-Technologies-Private-Limited/OpenDraft/releases/latest/download/OpenDraft_0.17.2_x64-setup.exe) |
-| **Windows** (MSI) | [Download .msi](https://github.com/Proteus-Technologies-Private-Limited/OpenDraft/releases/latest/download/OpenDraft_0.17.2_x64_en-US.msi) |
-| **Linux** (Debian/Ubuntu) | [Download .deb](https://github.com/Proteus-Technologies-Private-Limited/OpenDraft/releases/latest/download/OpenDraft_0.17.2_amd64.deb) |
-| **Linux** (AppImage) | [Download .AppImage](https://github.com/Proteus-Technologies-Private-Limited/OpenDraft/releases/latest/download/OpenDraft_0.17.2_amd64.AppImage) |
-| **Linux** (RPM/Fedora) | [Download .rpm](https://github.com/Proteus-Technologies-Private-Limited/OpenDraft/releases/latest/download/OpenDraft-0.17.2-1.x86_64.rpm) |
+| **macOS** (Apple Silicon) | [Download .dmg](https://github.com/Proteus-Technologies-Private-Limited/OpenDraft/releases/latest/download/OpenDraft_0.17.3_aarch64.dmg) |
+| **macOS** (Intel) | [Download .dmg](https://github.com/Proteus-Technologies-Private-Limited/OpenDraft/releases/latest/download/OpenDraft_0.17.3_x64.dmg) |
+| **Windows** (64-bit) | [Download .exe](https://github.com/Proteus-Technologies-Private-Limited/OpenDraft/releases/latest/download/OpenDraft_0.17.3_x64-setup.exe) |
+| **Windows** (MSI) | [Download .msi](https://github.com/Proteus-Technologies-Private-Limited/OpenDraft/releases/latest/download/OpenDraft_0.17.3_x64_en-US.msi) |
+| **Linux** (Debian/Ubuntu) | [Download .deb](https://github.com/Proteus-Technologies-Private-Limited/OpenDraft/releases/latest/download/OpenDraft_0.17.3_amd64.deb) |
+| **Linux** (AppImage) | [Download .AppImage](https://github.com/Proteus-Technologies-Private-Limited/OpenDraft/releases/latest/download/OpenDraft_0.17.3_amd64.AppImage) |
+| **Linux** (RPM/Fedora) | [Download .rpm](https://github.com/Proteus-Technologies-Private-Limited/OpenDraft/releases/latest/download/OpenDraft-0.17.3-1.x86_64.rpm) |
 
 ### Mobile
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -46,7 +46,7 @@ async def lifespan(app: FastAPI):
 app = FastAPI(
     title="OpenDraft API",
     description="Backend API for OpenDraft screenwriting application",
-    version="0.17.2",
+    version="0.17.3",
     lifespan=lifespan,
 )
 

--- a/frontend/src/components/MenuBar.tsx
+++ b/frontend/src/components/MenuBar.tsx
@@ -1670,7 +1670,7 @@ const MenuBar: React.FC<MenuBarProps> = ({ editor, onCollaborate, onJoinCollab, 
           <div className="dialog-header">About Open Draft</div>
           <div className="dialog-body about-body">
             <div className="about-title">Open Draft</div>
-            <div className="about-version">Version 0.17.2</div>
+            <div className="about-version">Version 0.17.3</div>
             <div className="about-tagline">Free, open-source screenwriting software</div>
 
             <div className="about-whats-new">

--- a/frontend/src/services/diagnostics.ts
+++ b/frontend/src/services/diagnostics.ts
@@ -98,7 +98,7 @@ function getAppVersion(): string {
   if (typeof window !== 'undefined' && (window as any).__OPENDRAFT_VERSION__) {
     return (window as any).__OPENDRAFT_VERSION__;
   }
-  return '0.17.2';
+  return '0.17.3';
 }
 
 /** Format a report as plain text suitable for pasting into a GitHub issue. */

--- a/landing/index.html
+++ b/landing/index.html
@@ -678,17 +678,17 @@
         <p class="section-desc">Available on every major platform. Free, no account needed. Most users are writing in under 2 minutes.</p>
       </div>
       <div class="download-grid">
-        <a href="https://github.com/Proteus-Technologies-Private-Limited/OpenDraft/releases/latest/download/OpenDraft_0.17.2_aarch64.dmg" class="download-card">
+        <a href="https://github.com/Proteus-Technologies-Private-Limited/OpenDraft/releases/latest/download/OpenDraft_0.17.3_aarch64.dmg" class="download-card">
           <svg class="platform-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5"><rect x="2" y="3" width="20" height="14" rx="2"/><line x1="8" y1="21" x2="16" y2="21"/><line x1="12" y1="17" x2="12" y2="21"/></svg>
           <h3>macOS</h3>
           <p>Apple Silicon .dmg</p>
         </a>
-        <a href="https://github.com/Proteus-Technologies-Private-Limited/OpenDraft/releases/latest/download/OpenDraft_0.17.2_x64-setup.exe" class="download-card">
+        <a href="https://github.com/Proteus-Technologies-Private-Limited/OpenDraft/releases/latest/download/OpenDraft_0.17.3_x64-setup.exe" class="download-card">
           <svg class="platform-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5"><rect x="2" y="3" width="20" height="14" rx="2"/><line x1="8" y1="21" x2="16" y2="21"/><line x1="12" y1="17" x2="12" y2="21"/></svg>
           <h3>Windows</h3>
           <p>64-bit installer</p>
         </a>
-        <a href="https://github.com/Proteus-Technologies-Private-Limited/OpenDraft/releases/latest/download/OpenDraft_0.17.2_amd64.deb" class="download-card">
+        <a href="https://github.com/Proteus-Technologies-Private-Limited/OpenDraft/releases/latest/download/OpenDraft_0.17.3_amd64.deb" class="download-card">
           <svg class="platform-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5"><rect x="4" y="2" width="16" height="20" rx="2"/><line x1="12" y1="18" x2="12" y2="18.01"/></svg>
           <h3>Linux</h3>
           <p>.deb / .AppImage / .rpm</p>
@@ -700,27 +700,27 @@
           More download options
         </summary>
         <div class="download-grid" style="margin-top:16px;">
-          <a href="https://github.com/Proteus-Technologies-Private-Limited/OpenDraft/releases/latest/download/OpenDraft_0.17.2_x64.dmg" class="download-card">
+          <a href="https://github.com/Proteus-Technologies-Private-Limited/OpenDraft/releases/latest/download/OpenDraft_0.17.3_x64.dmg" class="download-card">
             <svg class="platform-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5"><rect x="2" y="3" width="20" height="14" rx="2"/><line x1="8" y1="21" x2="16" y2="21"/><line x1="12" y1="17" x2="12" y2="21"/></svg>
             <h3>macOS (Intel)</h3>
             <p>For Intel Macs running macOS 12 Monterey or newer</p>
           </a>
-          <a href="https://github.com/Proteus-Technologies-Private-Limited/OpenDraft/releases/latest/download/OpenDraft_0.17.2_x86_64-legacy.dmg" class="download-card">
+          <a href="https://github.com/Proteus-Technologies-Private-Limited/OpenDraft/releases/latest/download/OpenDraft_0.17.3_x86_64-legacy.dmg" class="download-card">
             <svg class="platform-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5"><rect x="2" y="3" width="20" height="14" rx="2"/><line x1="8" y1="21" x2="16" y2="21"/><line x1="12" y1="17" x2="12" y2="21"/></svg>
             <h3>macOS (Older Intel)</h3>
             <p>For Intel Macs running macOS 10.13 High Sierra through 11 Big Sur</p>
           </a>
-          <a href="https://github.com/Proteus-Technologies-Private-Limited/OpenDraft/releases/latest/download/OpenDraft_0.17.2_x64_en-US.msi" class="download-card">
+          <a href="https://github.com/Proteus-Technologies-Private-Limited/OpenDraft/releases/latest/download/OpenDraft_0.17.3_x64_en-US.msi" class="download-card">
             <svg class="platform-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5"><rect x="2" y="3" width="20" height="14" rx="2"/><line x1="8" y1="21" x2="16" y2="21"/><line x1="12" y1="17" x2="12" y2="21"/></svg>
             <h3>Windows (MSI)</h3>
             <p>64-bit MSI installer</p>
           </a>
-          <a href="https://github.com/Proteus-Technologies-Private-Limited/OpenDraft/releases/latest/download/OpenDraft_0.17.2_amd64.AppImage" class="download-card">
+          <a href="https://github.com/Proteus-Technologies-Private-Limited/OpenDraft/releases/latest/download/OpenDraft_0.17.3_amd64.AppImage" class="download-card">
             <svg class="platform-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5"><rect x="4" y="2" width="16" height="20" rx="2"/><line x1="12" y1="18" x2="12" y2="18.01"/></svg>
             <h3>Linux (AppImage)</h3>
             <p>Portable, no install needed</p>
           </a>
-          <a href="https://github.com/Proteus-Technologies-Private-Limited/OpenDraft/releases/latest/download/OpenDraft_0.17.2_android.apk" class="download-card">
+          <a href="https://github.com/Proteus-Technologies-Private-Limited/OpenDraft/releases/latest/download/OpenDraft_0.17.3_android.apk" class="download-card">
             <svg class="platform-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5"><rect x="5" y="2" width="14" height="20" rx="3"/><line x1="12" y1="18" x2="12" y2="18.01"/></svg>
             <h3>Android (APK)</h3>
             <p>Sideload .apk</p>

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2404,7 +2404,7 @@ checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "opendraft"
-version = "0.17.2"
+version = "0.17.3"
 dependencies = [
  "jni",
  "ndk-context",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "opendraft"
-version = "0.17.2"
+version = "0.17.3"
 description = "OpenDraft - Professional Screenwriting Application"
 authors = ["OpenDraft"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-config-schema/schema.json",
   "productName": "OpenDraft",
-  "version": "0.17.2",
+  "version": "0.17.3",
   "identifier": "com.proteus.opendraft",
   "build": {
     "frontendDist": "../frontend/dist",

--- a/user-manual/beat-board.html
+++ b/user-manual/beat-board.html
@@ -176,7 +176,7 @@
 
   </div>
   <footer class="footer">
-    OpenDraft User Manual &middot; v0.17.2 &middot; Made by Proteus Technologies
+    OpenDraft User Manual &middot; v0.17.3 &middot; Made by Proteus Technologies
   </footer>
 </main>
 

--- a/user-manual/characters.html
+++ b/user-manual/characters.html
@@ -346,7 +346,7 @@
 
   </div>
   <footer class="footer">
-    OpenDraft User Manual &middot; v0.17.2 &middot; Made by Proteus Technologies
+    OpenDraft User Manual &middot; v0.17.3 &middot; Made by Proteus Technologies
   </footer>
 </main>
 

--- a/user-manual/collaboration.html
+++ b/user-manual/collaboration.html
@@ -243,7 +243,7 @@
 
   </div>
   <footer class="footer">
-    OpenDraft User Manual &middot; v0.17.2 &middot; Made by Proteus Technologies
+    OpenDraft User Manual &middot; v0.17.3 &middot; Made by Proteus Technologies
   </footer>
 </main>
 

--- a/user-manual/find-replace.html
+++ b/user-manual/find-replace.html
@@ -168,7 +168,7 @@
 
   </div>
   <footer class="footer">
-    OpenDraft User Manual &middot; v0.17.2 &middot; Made by Proteus Technologies
+    OpenDraft User Manual &middot; v0.17.3 &middot; Made by Proteus Technologies
   </footer>
 </main>
 

--- a/user-manual/formatting.html
+++ b/user-manual/formatting.html
@@ -375,7 +375,7 @@
 
   </div>
   <footer class="footer">
-    OpenDraft User Manual &middot; v0.17.2 &middot; Made by Proteus Technologies
+    OpenDraft User Manual &middot; v0.17.3 &middot; Made by Proteus Technologies
   </footer>
 </main>
 

--- a/user-manual/getting-started.html
+++ b/user-manual/getting-started.html
@@ -252,7 +252,7 @@
 
   </div>
   <footer class="footer">
-    OpenDraft User Manual &middot; v0.17.2 &middot; Made by Proteus Technologies
+    OpenDraft User Manual &middot; v0.17.3 &middot; Made by Proteus Technologies
   </footer>
 </main>
 

--- a/user-manual/import-export.html
+++ b/user-manual/import-export.html
@@ -184,7 +184,7 @@
 
   </div>
   <footer class="footer">
-    OpenDraft User Manual &middot; v0.17.2 &middot; Made by Proteus Technologies
+    OpenDraft User Manual &middot; v0.17.3 &middot; Made by Proteus Technologies
   </footer>
 </main>
 

--- a/user-manual/index-cards.html
+++ b/user-manual/index-cards.html
@@ -157,7 +157,7 @@
 
   </div>
   <footer class="footer">
-    OpenDraft User Manual &middot; v0.17.2 &middot; Made by Proteus Technologies
+    OpenDraft User Manual &middot; v0.17.3 &middot; Made by Proteus Technologies
   </footer>
 </main>
 

--- a/user-manual/index.html
+++ b/user-manual/index.html
@@ -251,7 +251,7 @@
 
   </div>
   <footer class="footer">
-    OpenDraft User Manual &middot; v0.17.2 &middot; Made by Proteus Technologies
+    OpenDraft User Manual &middot; v0.17.3 &middot; Made by Proteus Technologies
   </footer>
 </main>
 

--- a/user-manual/installation.html
+++ b/user-manual/installation.html
@@ -234,7 +234,7 @@ pip install -r backend/requirements.txt</code></pre>
 
   </div>
   <footer class="footer">
-    OpenDraft User Manual &middot; v0.17.2 &middot; Made by Proteus Technologies
+    OpenDraft User Manual &middot; v0.17.3 &middot; Made by Proteus Technologies
   </footer>
 </main>
 

--- a/user-manual/keyboard-shortcuts.html
+++ b/user-manual/keyboard-shortcuts.html
@@ -179,7 +179,7 @@
 
   </div>
   <footer class="footer">
-    OpenDraft User Manual &middot; v0.17.2 &middot; Made by Proteus Technologies
+    OpenDraft User Manual &middot; v0.17.3 &middot; Made by Proteus Technologies
   </footer>
 </main>
 

--- a/user-manual/locations.html
+++ b/user-manual/locations.html
@@ -172,7 +172,7 @@ INT. COFFEE SHOP - DAY</code></pre>
 
   </div>
   <footer class="footer">
-    OpenDraft User Manual &middot; v0.17.2 &middot; Made by Proteus Technologies
+    OpenDraft User Manual &middot; v0.17.3 &middot; Made by Proteus Technologies
   </footer>
 </main>
 

--- a/user-manual/page-setup.html
+++ b/user-manual/page-setup.html
@@ -200,7 +200,7 @@
 
   </div>
   <footer class="footer">
-    OpenDraft User Manual &middot; v0.17.2 &middot; Made by Proteus Technologies
+    OpenDraft User Manual &middot; v0.17.3 &middot; Made by Proteus Technologies
   </footer>
 </main>
 

--- a/user-manual/projects.html
+++ b/user-manual/projects.html
@@ -261,7 +261,7 @@
 
   </div>
   <footer class="footer">
-    OpenDraft User Manual &middot; v0.17.2 &middot; Made by Proteus Technologies
+    OpenDraft User Manual &middot; v0.17.3 &middot; Made by Proteus Technologies
   </footer>
 </main>
 

--- a/user-manual/revision-mode.html
+++ b/user-manual/revision-mode.html
@@ -167,7 +167,7 @@
 
   </div>
   <footer class="footer">
-    OpenDraft User Manual &middot; v0.17.2 &middot; Made by Proteus Technologies
+    OpenDraft User Manual &middot; v0.17.3 &middot; Made by Proteus Technologies
   </footer>
 </main>
 

--- a/user-manual/scene-navigator.html
+++ b/user-manual/scene-navigator.html
@@ -165,7 +165,7 @@
 
   </div>
   <footer class="footer">
-    OpenDraft User Manual &middot; v0.17.2 &middot; Made by Proteus Technologies
+    OpenDraft User Manual &middot; v0.17.3 &middot; Made by Proteus Technologies
   </footer>
 </main>
 

--- a/user-manual/script-notes.html
+++ b/user-manual/script-notes.html
@@ -171,7 +171,7 @@
 
   </div>
   <footer class="footer">
-    OpenDraft User Manual &middot; v0.17.2 &middot; Made by Proteus Technologies
+    OpenDraft User Manual &middot; v0.17.3 &middot; Made by Proteus Technologies
   </footer>
 </main>
 

--- a/user-manual/script-statistics.html
+++ b/user-manual/script-statistics.html
@@ -272,7 +272,7 @@
 
   </div>
   <footer class="footer">
-    OpenDraft User Manual &middot; v0.17.2 &middot; Made by Proteus Technologies
+    OpenDraft User Manual &middot; v0.17.3 &middot; Made by Proteus Technologies
   </footer>
 </main>
 

--- a/user-manual/spell-check.html
+++ b/user-manual/spell-check.html
@@ -153,7 +153,7 @@
 
   </div>
   <footer class="footer">
-    OpenDraft User Manual &middot; v0.17.2 &middot; Made by Proteus Technologies
+    OpenDraft User Manual &middot; v0.17.3 &middot; Made by Proteus Technologies
   </footer>
 </main>
 

--- a/user-manual/tags.html
+++ b/user-manual/tags.html
@@ -186,7 +186,7 @@
 
   </div>
   <footer class="footer">
-    OpenDraft User Manual &middot; v0.17.2 &middot; Made by Proteus Technologies
+    OpenDraft User Manual &middot; v0.17.3 &middot; Made by Proteus Technologies
   </footer>
 </main>
 

--- a/user-manual/themes.html
+++ b/user-manual/themes.html
@@ -132,7 +132,7 @@
 
   </div>
   <footer class="footer">
-    OpenDraft User Manual &middot; v0.17.2 &middot; Made by Proteus Technologies
+    OpenDraft User Manual &middot; v0.17.3 &middot; Made by Proteus Technologies
   </footer>
 </main>
 

--- a/user-manual/title-page.html
+++ b/user-manual/title-page.html
@@ -177,7 +177,7 @@
 
   </div>
   <footer class="footer">
-    OpenDraft User Manual &middot; v0.17.2 &middot; Made by Proteus Technologies
+    OpenDraft User Manual &middot; v0.17.3 &middot; Made by Proteus Technologies
   </footer>
 </main>
 

--- a/user-manual/version-history.html
+++ b/user-manual/version-history.html
@@ -210,7 +210,7 @@
 
   </div>
   <footer class="footer">
-    OpenDraft User Manual &middot; v0.17.2 &middot; Made by Proteus Technologies
+    OpenDraft User Manual &middot; v0.17.3 &middot; Made by Proteus Technologies
   </footer>
 </main>
 

--- a/user-manual/writing-screenplay.html
+++ b/user-manual/writing-screenplay.html
@@ -309,7 +309,7 @@
 
   </div>
   <footer class="footer">
-    OpenDraft User Manual &middot; v0.17.2 &middot; Made by Proteus Technologies
+    OpenDraft User Manual &middot; v0.17.3 &middot; Made by Proteus Technologies
   </footer>
 </main>
 


### PR DESCRIPTION
## Release v0.17.3

Version bump and download link updates. The release is already published and all builds are live.

**Safe to merge** — download links will start pointing to the new version after merge.