### PR TITLE
auth: account deletion, change password, device tracking, opt-in 2FA

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ venv/
 # Build output
 frontend/dist/
 collab-server/dist/
+*.tsbuildinfo
 __pycache__/
 *.pyc
 

--- a/backend/app/api/auth.py
+++ b/backend/app/api/auth.py
@@ -13,12 +13,13 @@ extra hop.
 from __future__ import annotations
 
 import logging
+import shutil
 from typing import Any
 
 import httpx
 from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
 
-from app.config import COLLAB_SERVER_URL
+from app.config import COLLAB_SERVER_URL, PROJECTS_DIR_BASE, _safe_user_id
 from app.dependencies import require_user
 from app.services.auth_service import AuthUser
 
@@ -27,7 +28,9 @@ logger = logging.getLogger(__name__)
 router = APIRouter()
 
 # Headers we forward from the client to collab (auth + content type).
-_FORWARD_REQUEST_HEADERS = {"authorization", "content-type", "accept", "accept-language"}
+# x-device-id is forwarded so the collab server's /devices endpoint can
+# flag the caller's current device in its response.
+_FORWARD_REQUEST_HEADERS = {"authorization", "content-type", "accept", "accept-language", "x-device-id"}
 # Headers to forward back from collab to the client (skip hop-by-hop).
 _HOP_BY_HOP = {
     "connection",
@@ -139,3 +142,75 @@ async def me(user: AuthUser = Depends(require_user)) -> dict[str, Any]:
         "displayName": user.display_name,
         "emailVerified": user.email_verified,
     }
+
+
+@router.post("/verify-device")
+async def verify_device(request: Request) -> Response:
+    """Confirm a new-device 2FA challenge with the emailed 6-digit code."""
+    return await _proxy(request, "POST", "verify-device")
+
+
+@router.post("/change-password")
+async def change_password(request: Request) -> Response:
+    return await _proxy(request, "POST", "change-password")
+
+
+@router.post("/two-factor")
+async def toggle_two_factor(request: Request) -> Response:
+    return await _proxy(request, "POST", "two-factor")
+
+
+@router.get("/devices")
+async def list_devices(request: Request) -> Response:
+    return await _proxy(request, "GET", "devices")
+
+
+@router.delete("/devices/{device_id}")
+async def revoke_device(device_id: str, request: Request) -> Response:
+    # device_id is opaque from the backend's perspective; the collab server
+    # validates ownership against the bearer token.
+    return await _proxy(request, "DELETE", f"devices/{device_id}")
+
+
+def _wipe_user_projects(user_id: str) -> None:
+    """Remove every screenplay/project owned by user_id from the on-disk store.
+
+    This is the local Python backend's portion of account deletion — the
+    collab server tears down the auth record, and this function tears down
+    the per-user projects directory under <PROJECTS_DIR_BASE>/users/<id>/.
+    Best-effort: failures are logged but do not block deletion.
+    """
+    try:
+        safe_id = _safe_user_id(user_id)
+        user_dir = PROJECTS_DIR_BASE / "users" / safe_id
+        if user_dir.exists():
+            shutil.rmtree(user_dir)
+            logger.info("Wiped user projects directory: %s", user_dir)
+    except Exception as exc:  # noqa: BLE001 — never block account deletion on cleanup
+        logger.warning("Failed to wipe user projects for %s: %s", user_id, exc)
+
+
+@router.delete("/account")
+async def delete_account(
+    request: Request,
+    user: AuthUser = Depends(require_user),
+) -> Response:
+    """Permanently delete the authenticated user's account.
+
+    Apple App Store Guideline 5.1.1(v) requires apps that support account
+    creation to also offer account deletion. We:
+
+      1. Delegate auth-side deletion to the collab server (proxied below).
+         It validates the password / typed confirmation, removes the user,
+         their refresh tokens, devices, and email verifications, and records
+         an audit event.
+      2. On success, also wipe this user's locally-stored cloud projects so
+         no screenplay data lingers in the per-user data directory.
+
+    The frontend is expected to first prompt the user to download any cloud
+    screenplays — once we return 200 there is no recovery path.
+    """
+    response = await _proxy(request, "DELETE", "account")
+    if 200 <= response.status_code < 300:
+        _wipe_user_projects(user.id)
+    return response

--- a/collab-server/src/db.ts
+++ b/collab-server/src/db.ts
@@ -14,6 +14,7 @@ export interface UserRow {
   display_name: string;
   created_at: string;
   updated_at: string;
+  two_factor_enabled: number;
 }
 
 export interface EmailVerificationRow {
@@ -31,6 +32,34 @@ export interface RefreshTokenRow {
   token_hash: string;
   expires_at: string;
   revoked: number;
+  created_at: string;
+  device_id: string | null;
+}
+
+export interface UserDeviceRow {
+  id: string;
+  user_id: string;
+  device_id: string;
+  device_name: string;
+  user_agent: string | null;
+  platform: string | null;
+  ip_address: string | null;
+  trusted: number;
+  first_seen_at: string;
+  last_seen_at: string;
+}
+
+export interface DeviceChallengeRow {
+  id: string;
+  user_id: string;
+  device_id: string;
+  device_name: string;
+  user_agent: string | null;
+  platform: string | null;
+  ip_address: string | null;
+  code: string;
+  expires_at: string;
+  used: number;
   created_at: string;
 }
 
@@ -68,7 +97,8 @@ const SCHEMA_SQL = `
     google_id TEXT UNIQUE,
     display_name TEXT NOT NULL,
     created_at TEXT NOT NULL,
-    updated_at TEXT NOT NULL
+    updated_at TEXT NOT NULL,
+    two_factor_enabled INTEGER DEFAULT 0
   );
 
   CREATE TABLE IF NOT EXISTS email_verifications (
@@ -86,6 +116,34 @@ const SCHEMA_SQL = `
     token_hash TEXT NOT NULL,
     expires_at TEXT NOT NULL,
     revoked INTEGER DEFAULT 0,
+    created_at TEXT NOT NULL,
+    device_id TEXT
+  );
+
+  CREATE TABLE IF NOT EXISTS user_devices (
+    id TEXT PRIMARY KEY,
+    user_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    device_id TEXT NOT NULL,
+    device_name TEXT NOT NULL,
+    user_agent TEXT,
+    platform TEXT,
+    ip_address TEXT,
+    trusted INTEGER DEFAULT 0,
+    first_seen_at TEXT NOT NULL,
+    last_seen_at TEXT NOT NULL
+  );
+
+  CREATE TABLE IF NOT EXISTS device_challenges (
+    id TEXT PRIMARY KEY,
+    user_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    device_id TEXT NOT NULL,
+    device_name TEXT NOT NULL,
+    user_agent TEXT,
+    platform TEXT,
+    ip_address TEXT,
+    code TEXT NOT NULL,
+    expires_at TEXT NOT NULL,
+    used INTEGER DEFAULT 0,
     created_at TEXT NOT NULL
   );
 
@@ -119,6 +177,11 @@ const SCHEMA_SQL = `
   CREATE INDEX IF NOT EXISTS idx_audit_log_created ON audit_log(created_at);
   CREATE INDEX IF NOT EXISTS idx_collab_sessions_project_script
     ON collab_sessions(project_id, script_id);
+  CREATE INDEX IF NOT EXISTS idx_user_devices_user ON user_devices(user_id);
+  CREATE UNIQUE INDEX IF NOT EXISTS idx_user_devices_user_device
+    ON user_devices(user_id, device_id);
+  CREATE INDEX IF NOT EXISTS idx_device_challenges_user_device
+    ON device_challenges(user_id, device_id);
 `;
 
 export async function initDB(): Promise<DBAdapter> {
@@ -143,6 +206,25 @@ export async function initDB(): Promise<DBAdapter> {
   // Migration: add created_by column to existing collab_sessions tables
   try {
     await adapter.run('ALTER TABLE collab_sessions ADD COLUMN created_by TEXT', []);
+  } catch {
+    // Column already exists — ignore
+  }
+
+  // Migration: add device_id column to existing refresh_tokens tables so we
+  // can attribute tokens to a specific device for the devices list / revoke
+  // flow. Older rows simply have NULL device_id.
+  try {
+    await adapter.run('ALTER TABLE refresh_tokens ADD COLUMN device_id TEXT', []);
+  } catch {
+    // Column already exists — ignore
+  }
+
+  // Migration: add two_factor_enabled column on existing users tables. Off
+  // by default — when on, login from an unrecognised device requires emailed
+  // 2FA confirmation; when off, login proceeds and we just send a heads-up
+  // "new device signed in" email.
+  try {
+    await adapter.run('ALTER TABLE users ADD COLUMN two_factor_enabled INTEGER DEFAULT 0', []);
   } catch {
     // Column already exists — ignore
   }

--- a/collab-server/src/routes/auth.ts
+++ b/collab-server/src/routes/auth.ts
@@ -6,6 +6,8 @@ import type { UserRow } from '../db';
 import * as tokenService from '../services/tokenService';
 import * as emailService from '../services/emailService';
 import * as auditService from '../services/auditService';
+import * as deviceService from '../services/deviceService';
+import type { DeviceInfo } from '../services/deviceService';
 import { requireAuth } from '../middleware/auth';
 import { strictLimiter, veryStrictLimiter } from '../middleware/rateLimit';
 import { config } from '../config';
@@ -14,18 +16,28 @@ const router = Router();
 
 // ── Validation schemas ──
 
+const deviceInfoSchema = z.object({
+  deviceId: z.string().min(8).max(128),
+  deviceName: z.string().min(1).max(120),
+  platform: z.string().max(64).optional().nullable(),
+}).optional();
+
+const passwordRule = z.string().min(8).max(128).regex(
+  /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d).+$/,
+  'Password must contain at least one uppercase letter, one lowercase letter, and one digit'
+);
+
 const registerSchema = z.object({
   email: z.string().email().max(255),
-  password: z.string().min(8).max(128).regex(
-    /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d).+$/,
-    'Password must contain at least one uppercase letter, one lowercase letter, and one digit'
-  ),
+  password: passwordRule,
   displayName: z.string().min(1).max(100),
+  device: deviceInfoSchema,
 });
 
 const loginSchema = z.object({
   email: z.string().email(),
   password: z.string().min(1),
+  device: deviceInfoSchema,
 });
 
 const refreshSchema = z.object({
@@ -43,6 +55,24 @@ const verifyEmailLinkSchema = z.object({
 
 const googleLoginSchema = z.object({
   idToken: z.string().min(1),
+  device: deviceInfoSchema,
+});
+
+const verifyDeviceSchema = z.object({
+  challengeId: z.string().min(8).max(128),
+  code: z.string().length(6),
+});
+
+const changePasswordSchema = z.object({
+  currentPassword: z.string().min(1),
+  newPassword: passwordRule,
+});
+
+const deleteAccountSchema = z.object({
+  // Password confirmation when the user has one. Google-only accounts can
+  // omit this and supply confirmation: 'DELETE' instead.
+  password: z.string().optional(),
+  confirmation: z.string().optional(),
 });
 
 // ── Helpers ──
@@ -54,11 +84,49 @@ function userResponse(user: UserRow | null) {
     email: user.email,
     displayName: user.display_name,
     emailVerified: Boolean(user.email_verified),
+    twoFactorEnabled: Boolean(user.two_factor_enabled),
   };
 }
 
 function getClientIp(req: any): string {
   return req.ip || req.connection?.remoteAddress || 'unknown';
+}
+
+function pickDeviceInfo(req: any, body: any): DeviceInfo | null {
+  const device = body?.device;
+  if (!device || typeof device.deviceId !== 'string' || typeof device.deviceName !== 'string') {
+    return null;
+  }
+  return {
+    deviceId: device.deviceId,
+    deviceName: device.deviceName,
+    platform: typeof device.platform === 'string' ? device.platform : null,
+    userAgent: typeof req.headers['user-agent'] === 'string' ? req.headers['user-agent'] : null,
+    ipAddress: getClientIp(req),
+  };
+}
+
+function deviceResponse(row: {
+  device_id: string;
+  device_name: string;
+  platform: string | null;
+  user_agent: string | null;
+  ip_address: string | null;
+  trusted: number;
+  first_seen_at: string;
+  last_seen_at: string;
+}, currentDeviceId?: string | null): Record<string, unknown> {
+  return {
+    deviceId: row.device_id,
+    deviceName: row.device_name,
+    platform: row.platform,
+    userAgent: row.user_agent,
+    ipAddress: row.ip_address,
+    trusted: Boolean(row.trusted),
+    firstSeenAt: row.first_seen_at,
+    lastSeenAt: row.last_seen_at,
+    current: currentDeviceId ? row.device_id === currentDeviceId : false,
+  };
 }
 
 // ── Routes ──
@@ -72,6 +140,7 @@ router.post('/register', veryStrictLimiter, async (req, res) => {
     }
 
     const { email, password, displayName } = parsed.data;
+    const deviceInfo = pickDeviceInfo(req, parsed.data);
 
     // Check if email already exists
     const existing = await userService.findUserByEmail(email);
@@ -82,7 +151,16 @@ router.post('/register', veryStrictLimiter, async (req, res) => {
 
     let user = await userService.createUser(email, password, displayName);
     const accessToken = tokenService.generateAccessToken(user.id, user.email);
-    const { token: refreshToken } = await tokenService.generateRefreshToken(user.id);
+    const { token: refreshToken } = await tokenService.generateRefreshToken(
+      user.id,
+      deviceInfo?.deviceId ?? null,
+    );
+
+    // The device that created the account is implicitly trusted — no 2FA prompt
+    // on the very first login.
+    if (deviceInfo) {
+      await deviceService.recordTrustedDevice(user.id, deviceInfo);
+    }
 
     // Send verification email if SMTP is configured, otherwise auto-verify
     if (config.smtpHost) {
@@ -115,6 +193,7 @@ router.post('/login', strictLimiter, async (req, res) => {
     }
 
     const { email, password } = parsed.data;
+    const deviceInfo = pickDeviceInfo(req, parsed.data);
     const user = await userService.findUserByEmail(email);
 
     if (!user) {
@@ -129,8 +208,64 @@ router.post('/login', strictLimiter, async (req, res) => {
       return;
     }
 
+    // Device tracking + (opt-in) new-device 2FA.
+    //
+    //   • If 2FA is enabled and the (user, device) pair is new, we email a
+    //     6-digit code and respond with a challenge — no tokens are issued
+    //     until the client posts the code to /verify-device.
+    //   • If 2FA is off (default), login proceeds normally; the device is
+    //     recorded as trusted and we email a "new device signed in" notice
+    //     so the user can spot unauthorized access.
+    //   • If no device info was provided (older clients), nothing changes —
+    //     login works exactly as before.
+    if (deviceInfo) {
+      const known = await deviceService.findDevice(user.id, deviceInfo.deviceId);
+      if (!known) {
+        if (user.two_factor_enabled) {
+          const challenge = await deviceService.createDeviceChallenge(user.id, deviceInfo);
+          if (!challenge) {
+            res.status(429).json({ error: 'Too many new-device verification attempts. Please try again later.' });
+            return;
+          }
+          await emailService.sendNewDeviceCode(
+            user.email,
+            challenge.code,
+            deviceInfo.deviceName,
+            deviceInfo.ipAddress ?? null,
+          );
+          await auditService.logEvent(
+            'new_device_challenge',
+            user.id,
+            null,
+            { device: deviceInfo.deviceName, deviceId: deviceInfo.deviceId },
+            getClientIp(req),
+          );
+          res.status(200).json({
+            deviceVerificationRequired: true,
+            challengeId: challenge.challengeId,
+            message: 'A verification code was emailed to confirm this new device.',
+          });
+          return;
+        }
+        // 2FA off — record the device and notify by email (best-effort).
+        await deviceService.recordTrustedDevice(user.id, deviceInfo);
+        try {
+          await emailService.sendNewDeviceNotice(
+            user.email,
+            deviceInfo.deviceName,
+            deviceInfo.ipAddress ?? null,
+          );
+        } catch { /* notification only — never block login */ }
+      } else {
+        await deviceService.touchDevice(user.id, deviceInfo.deviceId, deviceInfo.ipAddress ?? null);
+      }
+    }
+
     const accessToken = tokenService.generateAccessToken(user.id, user.email);
-    const { token: refreshToken } = await tokenService.generateRefreshToken(user.id);
+    const { token: refreshToken } = await tokenService.generateRefreshToken(
+      user.id,
+      deviceInfo?.deviceId ?? null,
+    );
 
     await auditService.logEvent('login', user.id, null, { email: user.email }, getClientIp(req));
 
@@ -141,6 +276,59 @@ router.post('/login', strictLimiter, async (req, res) => {
     });
   } catch (err) {
     console.error('Login error:', err);
+    res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+router.post('/verify-device', strictLimiter, async (req, res) => {
+  try {
+    const parsed = verifyDeviceSchema.safeParse(req.body);
+    if (!parsed.success) {
+      res.status(400).json({ error: 'Invalid input' });
+      return;
+    }
+
+    const challenge = await deviceService.consumeDeviceChallenge(
+      parsed.data.challengeId,
+      parsed.data.code,
+    );
+    if (!challenge) {
+      res.status(400).json({ error: 'Invalid or expired verification code' });
+      return;
+    }
+
+    const user = await userService.findUserById(challenge.user_id);
+    if (!user) {
+      res.status(404).json({ error: 'User not found' });
+      return;
+    }
+
+    await deviceService.recordTrustedDevice(user.id, {
+      deviceId: challenge.device_id,
+      deviceName: challenge.device_name,
+      userAgent: challenge.user_agent,
+      platform: challenge.platform,
+      ipAddress: challenge.ip_address,
+    });
+
+    const accessToken = tokenService.generateAccessToken(user.id, user.email);
+    const { token: refreshToken } = await tokenService.generateRefreshToken(user.id, challenge.device_id);
+
+    await auditService.logEvent(
+      'new_device_verified',
+      user.id,
+      null,
+      { device: challenge.device_name, deviceId: challenge.device_id },
+      getClientIp(req),
+    );
+
+    res.json({
+      user: userResponse(user),
+      accessToken,
+      refreshToken,
+    });
+  } catch (err) {
+    console.error('Verify device error:', err);
     res.status(500).json({ error: 'Internal server error' });
   }
 });
@@ -309,8 +497,16 @@ router.post('/google', strictLimiter, async (req, res) => {
       payload.name || payload.email.split('@')[0],
     );
 
+    const deviceInfo = pickDeviceInfo(req, parsed.data);
+    if (deviceInfo) {
+      await deviceService.recordTrustedDevice(user.id, deviceInfo);
+    }
+
     const accessToken = tokenService.generateAccessToken(user.id, user.email);
-    const { token: refreshToken } = await tokenService.generateRefreshToken(user.id);
+    const { token: refreshToken } = await tokenService.generateRefreshToken(
+      user.id,
+      deviceInfo?.deviceId ?? null,
+    );
 
     await auditService.logEvent('google_login', user.id, null, { email: user.email }, getClientIp(req));
 
@@ -345,6 +541,187 @@ router.get('/config', (req, res) => {
     googleEnabled: Boolean(config.googleClientId),
     emailVerificationRequired: Boolean(config.smtpHost),
   });
+});
+
+// ── Change password ──
+router.post('/change-password', requireAuth, veryStrictLimiter, async (req, res) => {
+  try {
+    const parsed = changePasswordSchema.safeParse(req.body);
+    if (!parsed.success) {
+      res.status(400).json({ error: 'Invalid input', details: parsed.error.flatten().fieldErrors });
+      return;
+    }
+
+    const user = await userService.findUserById(req.user!.id);
+    if (!user) {
+      res.status(404).json({ error: 'User not found' });
+      return;
+    }
+
+    if (!user.password_hash) {
+      // Google-only account: no password to change. Asks the user to set one
+      // by signing out and using "Forgot password" — which we don't have yet,
+      // so this is a hard error for now.
+      res.status(400).json({ error: 'This account does not use a password (signed in with Google).' });
+      return;
+    }
+
+    if (!(await userService.verifyPassword(user, parsed.data.currentPassword))) {
+      await auditService.logEvent(
+        'login_failed',
+        user.id,
+        null,
+        { reason: 'change_password_wrong_current' },
+        getClientIp(req),
+      );
+      res.status(401).json({ error: 'Current password is incorrect' });
+      return;
+    }
+
+    if (parsed.data.currentPassword === parsed.data.newPassword) {
+      res.status(400).json({ error: 'New password must be different from the current password' });
+      return;
+    }
+
+    await userService.updatePassword(user.id, parsed.data.newPassword);
+    // Invalidate every refresh token so other devices are forced to sign in
+    // again with the new password.
+    await tokenService.revokeAllRefreshTokens(user.id);
+
+    await auditService.logEvent('password_changed', user.id, null, null, getClientIp(req));
+
+    // Best-effort notification email — don't fail the request if SMTP fails.
+    const ua = typeof req.headers['user-agent'] === 'string' ? req.headers['user-agent'] : 'Unknown device';
+    try { await emailService.sendPasswordChangedNotice(user.email, ua); } catch { /* ignore */ }
+
+    res.json({ message: 'Password updated. Please sign in again on all devices.' });
+  } catch (err) {
+    console.error('Change password error:', err);
+    res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+// ── Devices ──
+router.get('/devices', requireAuth, async (req, res) => {
+  try {
+    const devices = await deviceService.listDevices(req.user!.id);
+    const currentDeviceId = typeof req.headers['x-device-id'] === 'string'
+      ? req.headers['x-device-id']
+      : null;
+    res.json({
+      devices: devices.map((d) => deviceResponse(d, currentDeviceId)),
+    });
+  } catch (err) {
+    console.error('List devices error:', err);
+    res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+router.delete('/devices/:deviceId', requireAuth, async (req, res) => {
+  try {
+    const rawDeviceId = req.params.deviceId;
+    const deviceId = Array.isArray(rawDeviceId) ? rawDeviceId[0] : rawDeviceId;
+    if (!deviceId || typeof deviceId !== 'string' || deviceId.length > 128) {
+      res.status(400).json({ error: 'Invalid deviceId' });
+      return;
+    }
+    const removed = await deviceService.deleteDevice(req.user!.id, deviceId);
+    if (!removed) {
+      res.status(404).json({ error: 'Device not found' });
+      return;
+    }
+    await auditService.logEvent(
+      'device_revoked',
+      req.user!.id,
+      null,
+      { deviceId },
+      getClientIp(req),
+    );
+    res.json({ message: 'Device revoked' });
+  } catch (err) {
+    console.error('Revoke device error:', err);
+    res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+// ── Two-factor verification preference ──
+const twoFactorSchema = z.object({ enabled: z.boolean() });
+
+router.post('/two-factor', requireAuth, async (req, res) => {
+  try {
+    const parsed = twoFactorSchema.safeParse(req.body);
+    if (!parsed.success) {
+      res.status(400).json({ error: 'Invalid input' });
+      return;
+    }
+    await userService.setTwoFactorEnabled(req.user!.id, parsed.data.enabled);
+    const fresh = await userService.findUserById(req.user!.id);
+    res.json({ user: userResponse(fresh) });
+  } catch (err) {
+    console.error('Toggle 2FA error:', err);
+    res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+// ── Account deletion (Apple Guideline 5.1.1(v)) ──
+//
+// Permanently deletes the user record and every server-side artifact that
+// belongs to it. The frontend is expected to clear local state and prompt the
+// user to download any cloud screenplays *before* hitting this endpoint —
+// the server cannot recover deleted data.
+router.delete('/account', requireAuth, veryStrictLimiter, async (req, res) => {
+  try {
+    const parsed = deleteAccountSchema.safeParse(req.body || {});
+    if (!parsed.success) {
+      res.status(400).json({ error: 'Invalid input' });
+      return;
+    }
+
+    const user = await userService.findUserById(req.user!.id);
+    if (!user) {
+      res.status(404).json({ error: 'User not found' });
+      return;
+    }
+
+    // For password accounts: require current password. For Google-only
+    // accounts the JWT itself is sufficient, but require the literal string
+    // "DELETE" as a typed confirmation so it cannot be triggered by accident.
+    if (user.password_hash) {
+      if (!parsed.data.password) {
+        res.status(400).json({ error: 'Password is required to confirm account deletion' });
+        return;
+      }
+      if (!(await userService.verifyPassword(user, parsed.data.password))) {
+        await auditService.logEvent(
+          'login_failed',
+          user.id,
+          null,
+          { reason: 'delete_account_wrong_password' },
+          getClientIp(req),
+        );
+        res.status(401).json({ error: 'Password is incorrect' });
+        return;
+      }
+    } else {
+      if (parsed.data.confirmation !== 'DELETE') {
+        res.status(400).json({ error: 'Type DELETE to confirm account deletion' });
+        return;
+      }
+    }
+
+    const emailForNotice = user.email;
+
+    await userService.deleteUser(user.id);
+
+    await auditService.logEvent('account_deleted', null, null, { email: emailForNotice }, getClientIp(req));
+
+    try { await emailService.sendAccountDeletedNotice(emailForNotice); } catch { /* ignore */ }
+
+    res.json({ message: 'Account deleted' });
+  } catch (err) {
+    console.error('Delete account error:', err);
+    res.status(500).json({ error: 'Internal server error' });
+  }
 });
 
 export default router;

--- a/collab-server/src/services/auditService.ts
+++ b/collab-server/src/services/auditService.ts
@@ -11,7 +11,12 @@ export type AuditAction =
   | 'document_store'
   | 'token_refresh'
   | 'email_verified'
-  | 'google_login';
+  | 'google_login'
+  | 'new_device_challenge'
+  | 'new_device_verified'
+  | 'password_changed'
+  | 'account_deleted'
+  | 'device_revoked';
 
 export async function logEvent(
   action: AuditAction,

--- a/collab-server/src/services/deviceService.ts
+++ b/collab-server/src/services/deviceService.ts
@@ -1,0 +1,183 @@
+/**
+ * Device tracking + new-device 2FA challenges.
+ *
+ * Each client (desktop, mobile, browser) generates a stable random device_id
+ * and sends it with login. If the (user_id, device_id) pair has never been
+ * seen, login is gated behind an emailed 6-digit code (see emailService).
+ *
+ * Devices are stored in `user_devices` and shown to the user in Settings so
+ * they can review/revoke any session that doesn't look like theirs.
+ */
+
+import { v4 as uuidv4 } from 'uuid';
+import { getDB } from '../db';
+import type { UserDeviceRow, DeviceChallengeRow } from '../db';
+
+export interface DeviceInfo {
+  deviceId: string;
+  deviceName: string;
+  userAgent?: string | null;
+  platform?: string | null;
+  ipAddress?: string | null;
+}
+
+const CHALLENGE_EXPIRY_MS = 15 * 60 * 1000; // 15 minutes
+const MAX_CHALLENGES_PER_USER_PER_HOUR = 10;
+
+export async function findDevice(
+  userId: string,
+  deviceId: string,
+): Promise<UserDeviceRow | null> {
+  const db = getDB();
+  const row = await db.get<UserDeviceRow>(
+    'SELECT * FROM user_devices WHERE user_id = ? AND device_id = ?',
+    [userId, deviceId],
+  );
+  return row ?? null;
+}
+
+export async function listDevices(userId: string): Promise<UserDeviceRow[]> {
+  const db = getDB();
+  return db.all<UserDeviceRow>(
+    'SELECT * FROM user_devices WHERE user_id = ? ORDER BY last_seen_at DESC',
+    [userId],
+  );
+}
+
+export async function recordTrustedDevice(
+  userId: string,
+  info: DeviceInfo,
+): Promise<UserDeviceRow> {
+  const db = getDB();
+  const existing = await findDevice(userId, info.deviceId);
+  const now = new Date().toISOString();
+
+  if (existing) {
+    await db.run(
+      `UPDATE user_devices
+       SET device_name = ?, user_agent = ?, platform = ?, ip_address = ?,
+           trusted = 1, last_seen_at = ?
+       WHERE id = ?`,
+      [
+        info.deviceName,
+        info.userAgent ?? null,
+        info.platform ?? null,
+        info.ipAddress ?? null,
+        now,
+        existing.id,
+      ],
+    );
+    return (await findDevice(userId, info.deviceId))!;
+  }
+
+  const id = uuidv4();
+  await db.run(
+    `INSERT INTO user_devices
+       (id, user_id, device_id, device_name, user_agent, platform, ip_address, trusted, first_seen_at, last_seen_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, 1, ?, ?)`,
+    [
+      id,
+      userId,
+      info.deviceId,
+      info.deviceName,
+      info.userAgent ?? null,
+      info.platform ?? null,
+      info.ipAddress ?? null,
+      now,
+      now,
+    ],
+  );
+  return (await findDevice(userId, info.deviceId))!;
+}
+
+export async function touchDevice(
+  userId: string,
+  deviceId: string,
+  ipAddress: string | null,
+): Promise<void> {
+  const db = getDB();
+  const now = new Date().toISOString();
+  await db.run(
+    'UPDATE user_devices SET last_seen_at = ?, ip_address = ? WHERE user_id = ? AND device_id = ?',
+    [now, ipAddress, userId, deviceId],
+  );
+}
+
+export async function deleteDevice(userId: string, deviceId: string): Promise<boolean> {
+  const db = getDB();
+  // Revoke any refresh tokens tied to this device first.
+  await db.run(
+    'UPDATE refresh_tokens SET revoked = 1 WHERE user_id = ? AND device_id = ?',
+    [userId, deviceId],
+  );
+  const result = await db.run(
+    'DELETE FROM user_devices WHERE user_id = ? AND device_id = ?',
+    [userId, deviceId],
+  );
+  return result.changes > 0;
+}
+
+export async function createDeviceChallenge(
+  userId: string,
+  info: DeviceInfo,
+): Promise<{ challengeId: string; code: string } | null> {
+  const db = getDB();
+  const now = new Date();
+  const oneHourAgo = new Date(now.getTime() - 60 * 60 * 1000).toISOString();
+
+  // Rate-limit: max challenges per user per hour to stop email-spam abuse.
+  const recent = await db.all<{ id: string }>(
+    'SELECT id FROM device_challenges WHERE user_id = ? AND created_at > ?',
+    [userId, oneHourAgo],
+  );
+  if (recent.length >= MAX_CHALLENGES_PER_USER_PER_HOUR) {
+    return null;
+  }
+
+  const code = String(Math.floor(100000 + Math.random() * 900000));
+  const id = uuidv4();
+  const expiresAt = new Date(now.getTime() + CHALLENGE_EXPIRY_MS).toISOString();
+
+  // Invalidate any older outstanding challenges for the same (user, device).
+  await db.run(
+    'UPDATE device_challenges SET used = 1 WHERE user_id = ? AND device_id = ? AND used = 0',
+    [userId, info.deviceId],
+  );
+
+  await db.run(
+    `INSERT INTO device_challenges
+       (id, user_id, device_id, device_name, user_agent, platform, ip_address, code, expires_at, used, created_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 0, ?)`,
+    [
+      id,
+      userId,
+      info.deviceId,
+      info.deviceName,
+      info.userAgent ?? null,
+      info.platform ?? null,
+      info.ipAddress ?? null,
+      code,
+      expiresAt,
+      now.toISOString(),
+    ],
+  );
+
+  return { challengeId: id, code };
+}
+
+export async function consumeDeviceChallenge(
+  challengeId: string,
+  code: string,
+): Promise<DeviceChallengeRow | null> {
+  const db = getDB();
+  const now = new Date().toISOString();
+  const row = await db.get<DeviceChallengeRow>(
+    `SELECT * FROM device_challenges
+     WHERE id = ? AND code = ? AND used = 0 AND expires_at > ?`,
+    [challengeId, code, now],
+  );
+  if (!row) return null;
+
+  await db.run('UPDATE device_challenges SET used = 1 WHERE id = ?', [row.id]);
+  return row;
+}

--- a/collab-server/src/services/emailService.ts
+++ b/collab-server/src/services/emailService.ts
@@ -88,3 +88,140 @@ export async function sendVerificationEmail(email: string, code: string): Promis
     `,
   });
 }
+
+export async function sendNewDeviceCode(
+  email: string,
+  code: string,
+  deviceName: string,
+  ipAddress: string | null,
+): Promise<void> {
+  const transport = getTransporter();
+  const ipLine = ipAddress ? `\nIP address: ${ipAddress}` : '';
+  if (!transport) {
+    console.log(`[Email] SMTP not configured. New-device code for ${email} on "${deviceName}": ${code}`);
+    return;
+  }
+
+  await transport.sendMail({
+    from: config.smtpFrom,
+    to: email,
+    subject: 'OpenDraft - New sign-in attempt',
+    text:
+      `We noticed a sign-in attempt to your OpenDraft account from a new device:\n\n` +
+      `Device: ${deviceName}${ipLine}\n\n` +
+      `Enter this 6-digit verification code to confirm it was you:\n\n${code}\n\n` +
+      `This code expires in 15 minutes.\n\n` +
+      `If you did not try to sign in, please change your password immediately and ` +
+      `review the active devices in OpenDraft Settings.`,
+    html: `
+      <div style="font-family: sans-serif; max-width: 440px; margin: 0 auto; padding: 20px;">
+        <h2 style="color: #333;">New sign-in attempt</h2>
+        <p>We noticed a sign-in attempt to your OpenDraft account from a new device:</p>
+        <div style="background: #f5f5f5; border-radius: 6px; padding: 12px 16px; margin: 12px 0;">
+          <div><strong>Device:</strong> ${deviceName}</div>
+          ${ipAddress ? `<div><strong>IP:</strong> ${ipAddress}</div>` : ''}
+        </div>
+        <p>Enter this 6-digit verification code to confirm it was you:</p>
+        <div style="font-size: 32px; font-weight: bold; letter-spacing: 8px; text-align: center; padding: 20px; background: #f5f5f5; border-radius: 8px; margin: 16px 0;">
+          ${code}
+        </div>
+        <p style="color: #666; font-size: 13px;">The code expires in 15 minutes.</p>
+        <p style="color: #b00; font-size: 13px;">
+          If this wasn't you, change your password immediately and review your devices
+          in OpenDraft → Settings → Account.
+        </p>
+      </div>
+    `,
+  });
+}
+
+export async function sendNewDeviceNotice(
+  email: string,
+  deviceName: string,
+  ipAddress: string | null,
+): Promise<void> {
+  const transport = getTransporter();
+  const ipLine = ipAddress ? `\nIP address: ${ipAddress}` : '';
+  if (!transport) {
+    console.log(`[Email] SMTP not configured. New-device notice for ${email} on "${deviceName}"`);
+    return;
+  }
+
+  await transport.sendMail({
+    from: config.smtpFrom,
+    to: email,
+    subject: 'OpenDraft - A new device just signed in',
+    text:
+      `A new device just signed in to your OpenDraft account:\n\n` +
+      `Device: ${deviceName}${ipLine}\n\n` +
+      `If this was you, you can ignore this email.\n\n` +
+      `If it wasn't, change your password immediately and revoke the device from ` +
+      `OpenDraft Settings → Account → Devices. You can also enable two-factor ` +
+      `verification there to require an emailed code on every new device.`,
+    html: `
+      <div style="font-family: sans-serif; max-width: 440px; margin: 0 auto; padding: 20px;">
+        <h2 style="color: #333;">A new device just signed in</h2>
+        <p>A new device just signed in to your OpenDraft account:</p>
+        <div style="background: #f5f5f5; border-radius: 6px; padding: 12px 16px; margin: 12px 0;">
+          <div><strong>Device:</strong> ${deviceName}</div>
+          ${ipAddress ? `<div><strong>IP:</strong> ${ipAddress}</div>` : ''}
+        </div>
+        <p>If this was you, you can ignore this email.</p>
+        <p style="color: #b00;">
+          If it wasn't, change your password immediately and revoke the device
+          from OpenDraft → Settings → Account → Devices. You can also enable
+          two-factor verification there.
+        </p>
+      </div>
+    `,
+  });
+}
+
+export async function sendPasswordChangedNotice(email: string, deviceName: string): Promise<void> {
+  const transport = getTransporter();
+  if (!transport) {
+    console.log(`[Email] SMTP not configured. Password-changed notice for ${email} ("${deviceName}")`);
+    return;
+  }
+  await transport.sendMail({
+    from: config.smtpFrom,
+    to: email,
+    subject: 'OpenDraft - Your password was changed',
+    text:
+      `Your OpenDraft password was just changed from "${deviceName}".\n\n` +
+      `If this wasn't you, please reset your password immediately and contact support.`,
+    html: `
+      <div style="font-family: sans-serif; max-width: 440px; margin: 0 auto; padding: 20px;">
+        <h2>Your OpenDraft password was changed</h2>
+        <p>Your password was just changed from <strong>${deviceName}</strong>.</p>
+        <p style="color: #b00;">If this wasn't you, reset your password immediately and contact support.</p>
+      </div>
+    `,
+  });
+}
+
+export async function sendAccountDeletedNotice(email: string): Promise<void> {
+  const transport = getTransporter();
+  if (!transport) {
+    console.log(`[Email] SMTP not configured. Account-deleted notice for ${email}`);
+    return;
+  }
+  await transport.sendMail({
+    from: config.smtpFrom,
+    to: email,
+    subject: 'OpenDraft - Your account was deleted',
+    text:
+      `Your OpenDraft account (${email}) and all associated data were just deleted at your request.\n\n` +
+      `If you did not request this, please contact support immediately — accounts cannot be recovered after deletion.`,
+    html: `
+      <div style="font-family: sans-serif; max-width: 440px; margin: 0 auto; padding: 20px;">
+        <h2>Your OpenDraft account was deleted</h2>
+        <p>Your account <strong>${email}</strong> and all associated data have been permanently deleted.</p>
+        <p style="color: #b00;">
+          If you did not request this, contact support immediately —
+          accounts cannot be recovered after deletion.
+        </p>
+      </div>
+    `,
+  });
+}

--- a/collab-server/src/services/tokenService.ts
+++ b/collab-server/src/services/tokenService.ts
@@ -16,7 +16,10 @@ export function generateAccessToken(userId: string, email: string): string {
   return jwt.sign(payload, config.jwtSecret, { expiresIn: config.jwtAccessExpiry as any });
 }
 
-export async function generateRefreshToken(userId: string): Promise<{ token: string; expiresAt: string }> {
+export async function generateRefreshToken(
+  userId: string,
+  deviceId: string | null = null,
+): Promise<{ token: string; expiresAt: string }> {
   const db = getDB();
   const token = crypto.randomBytes(48).toString('base64url');
   const tokenHash = bcrypt.hashSync(token, 10);
@@ -36,9 +39,9 @@ export async function generateRefreshToken(userId: string): Promise<{ token: str
   const expiresAt = new Date(now.getTime() + expiresMs).toISOString();
 
   await db.run(
-    `INSERT INTO refresh_tokens (id, user_id, token_hash, expires_at, revoked, created_at)
-     VALUES (?, ?, ?, ?, 0, ?)`,
-    [id, userId, tokenHash, expiresAt, now.toISOString()],
+    `INSERT INTO refresh_tokens (id, user_id, token_hash, expires_at, revoked, created_at, device_id)
+     VALUES (?, ?, ?, ?, 0, ?, ?)`,
+    [id, userId, tokenHash, expiresAt, now.toISOString(), deviceId],
   );
 
   return { token, expiresAt };
@@ -59,13 +62,13 @@ export async function rotateRefreshToken(oldToken: string): Promise<{ accessToke
   const now = new Date().toISOString();
 
   // Find all non-revoked, non-expired refresh tokens
-  const rows = await db.all<{ id: string; user_id: string; token_hash: string }>(
+  const rows = await db.all<{ id: string; user_id: string; token_hash: string; device_id: string | null }>(
     'SELECT * FROM refresh_tokens WHERE revoked = 0 AND expires_at > ?',
     [now],
   );
 
   // Find matching token
-  let matchedRow: { id: string; user_id: string } | null = null;
+  let matchedRow: { id: string; user_id: string; device_id: string | null } | null = null;
   for (const row of rows) {
     if (bcrypt.compareSync(oldToken, row.token_hash)) {
       matchedRow = row;
@@ -82,9 +85,10 @@ export async function rotateRefreshToken(oldToken: string): Promise<{ accessToke
   const user = await db.get<{ email: string }>('SELECT email FROM users WHERE id = ?', [matchedRow.user_id]);
   if (!user) return null;
 
-  // Issue new pair
+  // Issue new pair, preserving the device binding so the new refresh token
+  // is still attributable to the same device for the devices list / revoke.
   const accessToken = generateAccessToken(matchedRow.user_id, user.email);
-  const { token: refreshToken } = await generateRefreshToken(matchedRow.user_id);
+  const { token: refreshToken } = await generateRefreshToken(matchedRow.user_id, matchedRow.device_id);
 
   return { accessToken, refreshToken, userId: matchedRow.user_id };
 }

--- a/collab-server/src/services/userService.ts
+++ b/collab-server/src/services/userService.ts
@@ -71,3 +71,49 @@ export async function setEmailVerified(userId: string): Promise<void> {
   const now = new Date().toISOString();
   await db.run('UPDATE users SET email_verified = 1, updated_at = ? WHERE id = ?', [now, userId]);
 }
+
+export async function setTwoFactorEnabled(userId: string, enabled: boolean): Promise<void> {
+  const db = getDB();
+  const now = new Date().toISOString();
+  await db.run(
+    'UPDATE users SET two_factor_enabled = ?, updated_at = ? WHERE id = ?',
+    [enabled ? 1 : 0, now, userId],
+  );
+}
+
+export async function updatePassword(userId: string, newPassword: string): Promise<void> {
+  const db = getDB();
+  const now = new Date().toISOString();
+  const passwordHash = bcrypt.hashSync(newPassword, config.bcryptRounds);
+  await db.run(
+    'UPDATE users SET password_hash = ?, updated_at = ? WHERE id = ?',
+    [passwordHash, now, userId],
+  );
+}
+
+/**
+ * Delete a user and every record that references them.
+ *
+ * `users` is the parent of refresh_tokens, email_verifications, user_devices,
+ * and device_challenges via ON DELETE CASCADE — but we explicitly delete the
+ * children first so the same code path works on databases where cascades
+ * weren't defined when the table was first created (older deployments).
+ *
+ * The user's invite tokens (`collab_sessions.created_by`) and audit-log rows
+ * are not foreign-keyed; we null/blank them out so the user cannot be
+ * reidentified through them but the audit trail is preserved.
+ */
+export async function deleteUser(userId: string): Promise<void> {
+  const db = getDB();
+  await db.run('UPDATE collab_sessions SET active = 0 WHERE created_by = ?', [userId]);
+  await db.run('DELETE FROM device_challenges WHERE user_id = ?', [userId]);
+  await db.run('DELETE FROM user_devices WHERE user_id = ?', [userId]);
+  await db.run('DELETE FROM email_verifications WHERE user_id = ?', [userId]);
+  await db.run('DELETE FROM refresh_tokens WHERE user_id = ?', [userId]);
+  // Anonymise audit log so the deletion event is preserved without keeping PII.
+  await db.run(
+    "UPDATE audit_log SET user_id = NULL, detail = NULL WHERE user_id = ?",
+    [userId],
+  );
+  await db.run('DELETE FROM users WHERE id = ?', [userId]);
+}

--- a/frontend/src/components/CollabLoginDialog.tsx
+++ b/frontend/src/components/CollabLoginDialog.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { createPortal } from 'react-dom';
-import { collabAuthApi, handleAuthResponse } from '../services/collabAuth';
+import { collabAuthApi, handleAuthResponse, isDeviceChallenge } from '../services/collabAuth';
 import type { CollabServerConfig } from '../services/collabAuth';
 import { initDemoInfo, isDemoMode } from '../services/demoInfo';
 import { showToast } from './Toast';
@@ -56,6 +56,11 @@ const CollabLoginDialog: React.FC<CollabLoginDialogProps> = ({ onClose, onSucces
   const [showRegPw, setShowRegPw] = useState(false);
   const [showRegConfirm, setShowRegConfirm] = useState(false);
 
+  // New-device 2FA challenge — set when /login returns a challenge instead
+  // of tokens. Replaces the email/password fields with a code-entry form.
+  const [pendingChallenge, setPendingChallenge] = useState<{ challengeId: string; email: string } | null>(null);
+  const [deviceCode, setDeviceCode] = useState('');
+
   useEffect(() => {
     // One-time migration: purge the legacy key that stored email+password in
     // plaintext. The email-only replacement is under opendraft:rememberedEmail.
@@ -69,6 +74,12 @@ const CollabLoginDialog: React.FC<CollabLoginDialogProps> = ({ onClose, onSucces
     setLoading(true);
     try {
       const response = await collabAuthApi.login(loginEmail, loginPassword);
+      if (isDeviceChallenge(response)) {
+        setPendingChallenge({ challengeId: response.challengeId, email: loginEmail });
+        setDeviceCode('');
+        showToast(response.message || 'Verification code emailed for this new device.', 'info');
+        return;
+      }
       handleAuthResponse(response);
       if (rememberEmail) saveRememberedEmail(loginEmail);
       else clearRememberedEmail();
@@ -82,6 +93,24 @@ const CollabLoginDialog: React.FC<CollabLoginDialogProps> = ({ onClose, onSucces
       } else {
         showToast(msg, 'error');
       }
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleVerifyDevice = async () => {
+    if (!pendingChallenge || deviceCode.length !== 6) return;
+    setLoading(true);
+    try {
+      const response = await collabAuthApi.verifyDevice(pendingChallenge.challengeId, deviceCode);
+      handleAuthResponse(response);
+      if (rememberEmail) saveRememberedEmail(pendingChallenge.email);
+      showToast('Device verified — signed in.', 'success');
+      setPendingChallenge(null);
+      setDeviceCode('');
+      onSuccess();
+    } catch (err: any) {
+      showToast(err.message || 'Verification failed', 'error');
     } finally {
       setLoading(false);
     }
@@ -134,7 +163,8 @@ const CollabLoginDialog: React.FC<CollabLoginDialogProps> = ({ onClose, onSucces
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
     if (e.key === 'Enter') {
-      if (tab === 'login') handleLogin();
+      if (tab === 'login' && pendingChallenge) handleVerifyDevice();
+      else if (tab === 'login') handleLogin();
       else handleRegister();
     } else if (e.key === 'Escape') {
       onClose();
@@ -187,6 +217,41 @@ const CollabLoginDialog: React.FC<CollabLoginDialogProps> = ({ onClose, onSucces
           </div>
 
           {tab === 'login' ? (
+            pendingChallenge ? (
+              <div className="settings-auth-form">
+                <p style={{ margin: '0 0 12px', fontSize: 13, color: 'var(--fd-text-muted)' }}>
+                  A 6-digit verification code was emailed to <strong>{pendingChallenge.email}</strong>{' '}
+                  to confirm this new device. Enter it below to finish signing in.
+                </p>
+                <div className="settings-field">
+                  <label>Verification Code</label>
+                  <input
+                    className="dialog-input settings-verify-input"
+                    value={deviceCode}
+                    onChange={(e) => setDeviceCode(e.target.value.replace(/\D/g, '').slice(0, 6))}
+                    placeholder="000000"
+                    maxLength={6}
+                    autoFocus
+                  />
+                </div>
+                <div style={{ display: 'flex', gap: 8 }}>
+                  <button
+                    className="dialog-btn dialog-btn-primary settings-auth-submit"
+                    onClick={handleVerifyDevice}
+                    disabled={deviceCode.length !== 6 || loading}
+                  >
+                    {loading ? 'Verifying...' : 'Verify Device'}
+                  </button>
+                  <button
+                    className="dialog-btn"
+                    onClick={() => { setPendingChallenge(null); setDeviceCode(''); }}
+                    disabled={loading}
+                  >
+                    Cancel
+                  </button>
+                </div>
+              </div>
+            ) : (
             <div className="settings-auth-form">
               <div className="settings-field">
                 <label>Email</label>
@@ -228,6 +293,7 @@ const CollabLoginDialog: React.FC<CollabLoginDialogProps> = ({ onClose, onSucces
                 {loading ? 'Signing in...' : 'Sign In'}
               </button>
             </div>
+            )
           ) : (
             <div className="settings-auth-form">
               <div className="settings-field">

--- a/frontend/src/components/SettingsPage.tsx
+++ b/frontend/src/components/SettingsPage.tsx
@@ -1,11 +1,12 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useSettingsStore } from '../stores/settingsStore';
-import { collabAuthApi, handleAuthResponse, performLogout } from '../services/collabAuth';
-import type { CollabServerConfig } from '../services/collabAuth';
+import { collabAuthApi, handleAuthResponse, performLogout, isDeviceChallenge } from '../services/collabAuth';
+import type { CollabServerConfig, DeviceRecord } from '../services/collabAuth';
 import { initDemoInfo, isDemoMode } from '../services/demoInfo';
 import { showToast } from './Toast';
 import { getApiBase } from '../config';
+import { getDeviceId } from '../services/deviceId';
 
 const EXPIRY_OPTIONS = [
   { label: '30 minutes', hours: 0.5 },
@@ -65,6 +66,34 @@ const SettingsPage: React.FC = () => {
   // Email verification
   const [verifyCode, setVerifyCode] = useState('');
   const [verifying, setVerifying] = useState(false);
+
+  // New-device 2FA challenge (only set when /login returns a challenge)
+  const [pendingChallenge, setPendingChallenge] = useState<{ challengeId: string; email: string } | null>(null);
+  const [deviceCode, setDeviceCode] = useState('');
+  const [verifyingDevice, setVerifyingDevice] = useState(false);
+
+  // Account management state
+  const [showAccount, setShowAccount] = useState(false);
+  const [currentPassword, setCurrentPassword] = useState('');
+  const [newPassword, setNewPassword] = useState('');
+  const [newPasswordConfirm, setNewPasswordConfirm] = useState('');
+  const [changingPassword, setChangingPassword] = useState(false);
+
+  const [twoFactorBusy, setTwoFactorBusy] = useState(false);
+
+  const [devices, setDevices] = useState<DeviceRecord[] | null>(null);
+  const [devicesLoading, setDevicesLoading] = useState(false);
+
+  const [deleteOpen, setDeleteOpen] = useState(false);
+  const [deletePassword, setDeletePassword] = useState('');
+  const [deleteConfirmation, setDeleteConfirmation] = useState('');
+  const [deleting, setDeleting] = useState(false);
+  // Cloud screenplay inventory — populated when the delete dialog opens so we
+  // can warn the user about exactly what they'll lose. Empty array = none on
+  // file; null = not loaded yet (or load failed and we proceed with the
+  // generic warning).
+  const [cloudInventory, setCloudInventory] = useState<{ projects: number; scripts: number } | null>(null);
+  const [inventoryLoading, setInventoryLoading] = useState(false);
 
   // Google OAuth
   const [serverConfig, setServerConfig] = useState<CollabServerConfig | null>(null);
@@ -158,6 +187,14 @@ const SettingsPage: React.FC = () => {
     setAuthLoading(true);
     try {
       const response = await collabAuthApi.login(loginEmail, loginPassword);
+      if (isDeviceChallenge(response)) {
+        // 2FA enabled and this device is new — server emailed a code instead
+        // of issuing tokens. Hand off to the device-verification UI.
+        setPendingChallenge({ challengeId: response.challengeId, email: loginEmail });
+        setDeviceCode('');
+        showToast(response.message || 'Verification code emailed for this new device.', 'info');
+        return;
+      }
       handleAuthResponse(response);
       try {
         if (rememberEmail) localStorage.setItem('opendraft:rememberedEmail', loginEmail);
@@ -176,6 +213,27 @@ const SettingsPage: React.FC = () => {
       }
     } finally {
       setAuthLoading(false);
+    }
+  };
+
+  const handleVerifyDevice = async () => {
+    if (!pendingChallenge || deviceCode.length !== 6) return;
+    setVerifyingDevice(true);
+    try {
+      const response = await collabAuthApi.verifyDevice(pendingChallenge.challengeId, deviceCode);
+      handleAuthResponse(response);
+      try {
+        if (rememberEmail) localStorage.setItem('opendraft:rememberedEmail', pendingChallenge.email);
+      } catch { /* ignore */ }
+      showToast('Device verified — you are signed in.', 'success');
+      setPendingChallenge(null);
+      setDeviceCode('');
+      setLoginEmail('');
+      setLoginPassword('');
+    } catch (err: any) {
+      showToast(err.message || 'Verification failed', 'error');
+    } finally {
+      setVerifyingDevice(false);
     }
   };
 
@@ -267,6 +325,164 @@ const SettingsPage: React.FC = () => {
   const handleLogout = async () => {
     await performLogout();
     showToast('Logged out', 'success');
+  };
+
+  // ── Account: change password ──
+  const handleChangePassword = async () => {
+    if (!currentPassword || !newPassword || !newPasswordConfirm) return;
+    if (newPassword !== newPasswordConfirm) {
+      showToast('New passwords do not match', 'error');
+      return;
+    }
+    if (newPassword.length < 8 || !/^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)/.test(newPassword)) {
+      showToast('New password must be 8+ chars with upper, lower, and digit', 'error');
+      return;
+    }
+    setChangingPassword(true);
+    try {
+      await collabAuthApi.changePassword(currentPassword, newPassword);
+      // Server revokes every refresh token — sign the user out so they
+      // re-authenticate with the new password.
+      showToast('Password changed. Please sign in again.', 'success');
+      setCurrentPassword('');
+      setNewPassword('');
+      setNewPasswordConfirm('');
+      await performLogout();
+    } catch (err: any) {
+      showToast(err.message || 'Could not change password', 'error');
+    } finally {
+      setChangingPassword(false);
+    }
+  };
+
+  // ── Account: two-factor toggle ──
+  const handleToggleTwoFactor = async (enabled: boolean) => {
+    setTwoFactorBusy(true);
+    try {
+      const r = await collabAuthApi.setTwoFactorEnabled(enabled);
+      useSettingsStore.getState().setCollabAuth({
+        ...useSettingsStore.getState().collabAuth,
+        user: r.user,
+      });
+      showToast(
+        enabled
+          ? 'Two-factor verification turned on. New devices will need an emailed code.'
+          : 'Two-factor verification turned off. New sign-ins will only get a notification email.',
+        'success',
+      );
+    } catch (err: any) {
+      showToast(err.message || 'Could not update 2FA setting', 'error');
+    } finally {
+      setTwoFactorBusy(false);
+    }
+  };
+
+  // ── Account: devices list ──
+  const refreshDevices = useCallback(async () => {
+    setDevicesLoading(true);
+    try {
+      const list = await collabAuthApi.listDevices();
+      setDevices(list);
+    } catch (err: any) {
+      showToast(err.message || 'Could not load devices', 'error');
+      setDevices([]);
+    } finally {
+      setDevicesLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (showAccount && isLoggedIn && devices === null && !devicesLoading) {
+      void refreshDevices();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [showAccount, isLoggedIn]);
+
+  const handleRevokeDevice = async (deviceId: string) => {
+    if (deviceId === getDeviceId()) {
+      showToast('Use Sign Out to remove the current device.', 'error');
+      return;
+    }
+    if (!confirm('Sign this device out and revoke its sessions?')) return;
+    try {
+      await collabAuthApi.revokeDevice(deviceId);
+      showToast('Device revoked', 'success');
+      await refreshDevices();
+    } catch (err: any) {
+      showToast(err.message || 'Could not revoke device', 'error');
+    }
+  };
+
+  // ── Account: delete account (Apple Guideline 5.1.1(v)) ──
+  const cloudPortalLink = (() => {
+    const base = getApiBase();
+    if (!base) return '';
+    return base.replace(/\/api\/?$/, '');
+  })();
+
+  // Load the user's cloud screenplay count when the user opens the delete
+  // dialog so the warning can name the actual amount they're about to lose.
+  // Best-effort: if the cloud is unreachable or returns 401 we leave the
+  // generic warning in place — better to under-warn than block the deletion
+  // flow on a network hiccup.
+  const loadCloudInventory = useCallback(async () => {
+    setInventoryLoading(true);
+    setCloudInventory(null);
+    try {
+      const { cloudApi } = await import('../services/cloudApi');
+      const projects = await cloudApi.listProjects();
+      let scripts = 0;
+      // The list endpoint already returns project metadata; counting scripts
+      // is a per-project API hop. Limit it to the first 25 projects so we
+      // don't make a long sequence of requests in the worst case — anything
+      // past that is good enough as an "X+ screenplays" warning.
+      const sample = projects.slice(0, 25);
+      for (const p of sample) {
+        try {
+          const list = await cloudApi.listScripts(p.id, false);
+          scripts += list.length;
+        } catch { /* ignore per-project failure */ }
+      }
+      setCloudInventory({ projects: projects.length, scripts });
+    } catch {
+      setCloudInventory(null);
+    } finally {
+      setInventoryLoading(false);
+    }
+  }, []);
+
+  const handleOpenDelete = () => {
+    setDeleteOpen(true);
+    void loadCloudInventory();
+  };
+
+  const handleDeleteAccount = async () => {
+    if (!collabAuth.user) return;
+    if (deleteConfirmation !== 'DELETE') {
+      showToast('Type DELETE to confirm.', 'error');
+      return;
+    }
+    setDeleting(true);
+    try {
+      // Always send both fields when present — the server picks the right one
+      // based on whether the account has a password set. We can't tell from
+      // the client because /auth/me doesn't expose that detail.
+      const opts: { password?: string; confirmation?: string } = {
+        confirmation: deleteConfirmation,
+      };
+      if (deletePassword) opts.password = deletePassword;
+      await collabAuthApi.deleteAccount(opts);
+      showToast('Account deleted. We are sorry to see you go.', 'success');
+      setDeleteOpen(false);
+      setDeletePassword('');
+      setDeleteConfirmation('');
+      // Clear local auth state — the access token now references a deleted user.
+      useSettingsStore.getState().clearCollabAuth();
+    } catch (err: any) {
+      showToast(err.message || 'Could not delete account', 'error');
+    } finally {
+      setDeleting(false);
+    }
   };
 
   const handleKeyDown = (e: React.KeyboardEvent, action: () => void) => {
@@ -454,6 +670,43 @@ const SettingsPage: React.FC = () => {
               </div>
 
               {authTab === 'login' ? (
+                pendingChallenge ? (
+                  <div className="settings-auth-form">
+                    <div className="settings-verify-text">
+                      A 6-digit verification code was emailed to{' '}
+                      <strong>{pendingChallenge.email}</strong> to confirm this is a
+                      device you trust. Enter it below to finish signing in.
+                    </div>
+                    <div className="settings-field">
+                      <label>Verification Code</label>
+                      <input
+                        className="dialog-input settings-verify-input"
+                        value={deviceCode}
+                        onChange={(e) => setDeviceCode(e.target.value.replace(/\D/g, '').slice(0, 6))}
+                        placeholder="000000"
+                        maxLength={6}
+                        autoFocus
+                        onKeyDown={(e) => handleKeyDown(e, handleVerifyDevice)}
+                      />
+                    </div>
+                    <div className="settings-verify-row">
+                      <button
+                        className="dialog-btn dialog-btn-primary"
+                        onClick={handleVerifyDevice}
+                        disabled={deviceCode.length !== 6 || verifyingDevice}
+                      >
+                        {verifyingDevice ? 'Verifying...' : 'Verify Device'}
+                      </button>
+                      <button
+                        className="dialog-btn"
+                        onClick={() => { setPendingChallenge(null); setDeviceCode(''); }}
+                        disabled={verifyingDevice}
+                      >
+                        Cancel
+                      </button>
+                    </div>
+                  </div>
+                ) : (
                 <div className="settings-auth-form">
                   <div className="settings-field">
                     <label>Email</label>
@@ -485,6 +738,7 @@ const SettingsPage: React.FC = () => {
                     {authLoading ? 'Signing in...' : 'Sign In'}
                   </button>
                 </div>
+                )
               ) : (
                 <div className="settings-auth-form">
                   <div className="settings-field">
@@ -581,6 +835,243 @@ const SettingsPage: React.FC = () => {
             </div>
           )}
         </section>
+
+        {/* ── Account & Security (signed-in users only) ── */}
+        {isLoggedIn && (
+          <section className="settings-section">
+            <h2 className="settings-section-title">Account &amp; Security</h2>
+            <p className="settings-section-desc">
+              Manage your password, devices, two-factor verification, and account deletion.
+            </p>
+
+            {!showAccount ? (
+              <button className="dialog-btn" onClick={() => setShowAccount(true)}>
+                Open Account Settings
+              </button>
+            ) : (
+              <div className="settings-auth-card">
+                {/* Two-factor toggle */}
+                <div className="settings-account-block">
+                  <div className="settings-account-row">
+                    <div>
+                      <div className="settings-account-title">Two-factor verification</div>
+                      <div className="settings-account-hint">
+                        When on, signing in from a new device requires a 6-digit code emailed to
+                        you. When off, you'll only get a heads-up email so you can spot
+                        unauthorized sign-ins.
+                      </div>
+                    </div>
+                    <label className="settings-switch">
+                      <input
+                        type="checkbox"
+                        checked={Boolean(collabAuth.user?.twoFactorEnabled)}
+                        disabled={twoFactorBusy}
+                        onChange={(e) => handleToggleTwoFactor(e.target.checked)}
+                      />
+                      <span>{collabAuth.user?.twoFactorEnabled ? 'On' : 'Off'}</span>
+                    </label>
+                  </div>
+                </div>
+
+                {/* Change password */}
+                <div className="settings-account-block">
+                  <div className="settings-account-title">Change password</div>
+                  <div className="settings-account-hint">
+                    Updating your password will sign you out everywhere. You'll need to sign in
+                    again with the new password on each device.
+                  </div>
+                  <div className="settings-field">
+                    <label>Current Password</label>
+                    <input
+                      className="dialog-input"
+                      type="password"
+                      value={currentPassword}
+                      onChange={(e) => setCurrentPassword(e.target.value)}
+                      placeholder="Current password"
+                      autoComplete="current-password"
+                    />
+                  </div>
+                  <div className="settings-field">
+                    <label>New Password</label>
+                    <input
+                      className="dialog-input"
+                      type="password"
+                      value={newPassword}
+                      onChange={(e) => setNewPassword(e.target.value)}
+                      placeholder="At least 8 characters"
+                      autoComplete="new-password"
+                    />
+                  </div>
+                  <div className="settings-field">
+                    <label>Confirm New Password</label>
+                    <input
+                      className="dialog-input"
+                      type="password"
+                      value={newPasswordConfirm}
+                      onChange={(e) => setNewPasswordConfirm(e.target.value)}
+                      placeholder="Repeat new password"
+                      autoComplete="new-password"
+                    />
+                  </div>
+                  <button
+                    className="dialog-btn dialog-btn-primary"
+                    onClick={handleChangePassword}
+                    disabled={!currentPassword || !newPassword || !newPasswordConfirm || changingPassword}
+                  >
+                    {changingPassword ? 'Updating...' : 'Update Password'}
+                  </button>
+                </div>
+
+                {/* Devices */}
+                <div className="settings-account-block">
+                  <div className="settings-account-row">
+                    <div>
+                      <div className="settings-account-title">Active devices</div>
+                      <div className="settings-account-hint">
+                        These are the devices currently signed in to your account. Revoke any
+                        you don't recognise — that device will be signed out immediately.
+                      </div>
+                    </div>
+                    <button className="dialog-btn" onClick={refreshDevices} disabled={devicesLoading}>
+                      {devicesLoading ? 'Loading...' : 'Refresh'}
+                    </button>
+                  </div>
+                  {devicesLoading && devices === null ? (
+                    <div className="settings-account-hint">Loading devices…</div>
+                  ) : (devices || []).length === 0 ? (
+                    <div className="settings-account-hint">No registered devices yet.</div>
+                  ) : (
+                    <ul className="settings-device-list">
+                      {(devices || []).map((d) => (
+                        <li key={d.deviceId} className="settings-device-row">
+                          <div className="settings-device-info">
+                            <div className="settings-device-name">
+                              {d.deviceName}
+                              {d.current && <span className="settings-device-current"> (this device)</span>}
+                            </div>
+                            <div className="settings-device-meta">
+                              {d.platform || 'Unknown platform'}
+                              {d.ipAddress ? ` · ${d.ipAddress}` : ''}
+                            </div>
+                            <div className="settings-device-meta">
+                              Last seen {new Date(d.lastSeenAt).toLocaleString()}
+                            </div>
+                          </div>
+                          {!d.current && (
+                            <button
+                              className="dialog-btn dialog-btn-danger"
+                              onClick={() => handleRevokeDevice(d.deviceId)}
+                            >
+                              Revoke
+                            </button>
+                          )}
+                        </li>
+                      ))}
+                    </ul>
+                  )}
+                </div>
+
+                {/* Delete account (Apple Guideline 5.1.1(v)) */}
+                <div className="settings-account-block settings-account-danger">
+                  <div className="settings-account-title">Delete account</div>
+                  <div className="settings-account-hint">
+                    Permanently deletes your account, password, devices, and any cloud
+                    screenplays stored under your account. This cannot be undone.
+                  </div>
+                  {!deleteOpen ? (
+                    <button
+                      className="dialog-btn dialog-btn-danger"
+                      onClick={handleOpenDelete}
+                    >
+                      Delete Account…
+                    </button>
+                  ) : (
+                    <div className="settings-delete-confirm">
+                      <div className="settings-delete-warning">
+                        <strong>Before you continue:</strong>{' '}
+                        {inventoryLoading ? (
+                          <>checking your OpenDraft Cloud account for screenplays…</>
+                        ) : cloudInventory && (cloudInventory.projects > 0 || cloudInventory.scripts > 0) ? (
+                          <>
+                            you have <strong>{cloudInventory.projects}</strong>{' '}
+                            project{cloudInventory.projects === 1 ? '' : 's'}
+                            {cloudInventory.scripts > 0 && (
+                              <>
+                                {' '}with at least <strong>{cloudInventory.scripts}</strong>{' '}
+                                screenplay{cloudInventory.scripts === 1 ? '' : 's'}
+                              </>
+                            )}{' '}
+                            stored in OpenDraft Cloud. They will be permanently deleted along
+                            with this account and cannot be recovered. Please open each one in
+                            OpenDraft and use <em>File → Save As / Export</em> to download a
+                            local copy before continuing.
+                          </>
+                        ) : (
+                          <>
+                            any screenplays stored in OpenDraft Cloud under this account will be
+                            deleted along with the account and cannot be recovered. Please make
+                            sure you have downloaded them first.
+                          </>
+                        )}
+                        {cloudPortalLink && (
+                          <>
+                            {' '}You can review and download them from{' '}
+                            <a href={cloudPortalLink} target="_blank" rel="noreferrer">
+                              {cloudPortalLink}
+                            </a>.
+                          </>
+                        )}
+                      </div>
+
+                      <div className="settings-field">
+                        <label>Current password (leave blank for Google-only accounts)</label>
+                        <input
+                          className="dialog-input"
+                          type="password"
+                          value={deletePassword}
+                          onChange={(e) => setDeletePassword(e.target.value)}
+                          placeholder="Your password"
+                          autoComplete="current-password"
+                        />
+                      </div>
+
+                      <div className="settings-field">
+                        <label>Type <strong>DELETE</strong> to confirm</label>
+                        <input
+                          className="dialog-input"
+                          value={deleteConfirmation}
+                          onChange={(e) => setDeleteConfirmation(e.target.value)}
+                          placeholder="DELETE"
+                        />
+                      </div>
+
+                      <div className="settings-verify-row">
+                        <button
+                          className="dialog-btn dialog-btn-danger"
+                          onClick={handleDeleteAccount}
+                          disabled={deleting || deleteConfirmation !== 'DELETE'}
+                        >
+                          {deleting ? 'Deleting...' : 'Permanently delete my account'}
+                        </button>
+                        <button
+                          className="dialog-btn"
+                          onClick={() => {
+                            setDeleteOpen(false);
+                            setDeletePassword('');
+                            setDeleteConfirmation('');
+                          }}
+                          disabled={deleting}
+                        >
+                          Cancel
+                        </button>
+                      </div>
+                    </div>
+                  )}
+                </div>
+              </div>
+            )}
+          </section>
+        )}
 
         {/* ── Invite Defaults ── */}
         <section className="settings-section">

--- a/frontend/src/services/collabAuth.ts
+++ b/frontend/src/services/collabAuth.ts
@@ -3,6 +3,7 @@ import { useSettingsStore } from '../stores/settingsStore';
 import type { CollabAuth, CollabUser } from '../stores/settingsStore';
 import { platformFetch } from './platform';
 import { authedFetch } from './authedFetch';
+import { getDeviceInfo, getDeviceId } from './deviceId';
 
 // ── URL helpers ──
 
@@ -54,13 +55,37 @@ async function backendAuthRequest<T>(path: string, options?: RequestInit): Promi
     // content block on plain HTTP backends.
     res = await platformFetch(url, {
       ...options,
-      headers: { 'Content-Type': 'application/json', ...options?.headers },
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Device-Id': getDeviceId(),
+        ...options?.headers,
+      },
     });
   } catch (err) {
     throw wrapNetworkError(err, 'the OpenDraft backend');
   }
   if (!res.ok) throw await parseError(res, 'Auth');
   return res.json();
+}
+
+async function backendAuthRequestRaw(path: string, options?: RequestInit): Promise<Response> {
+  const base = getApiBase();
+  if (!base) {
+    throw new Error('OpenDraft Cloud is not configured for this app. Open Settings → System Settings to set the OpenDraft server URL.');
+  }
+  const url = `${base}/auth${path}`;
+  try {
+    return await platformFetch(url, {
+      ...options,
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Device-Id': getDeviceId(),
+        ...options?.headers,
+      },
+    });
+  } catch (err) {
+    throw wrapNetworkError(err, 'the OpenDraft backend');
+  }
 }
 
 /** Same as backendAuthRequest but attaches the bearer token and refreshes on 401. */
@@ -74,7 +99,11 @@ async function backendAuthedRequest<T>(path: string, options?: RequestInit): Pro
   try {
     res = await authedFetch(url, {
       ...options,
-      headers: { 'Content-Type': 'application/json', ...options?.headers },
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Device-Id': getDeviceId(),
+        ...options?.headers,
+      },
     });
   } catch (err) {
     throw wrapNetworkError(err, 'the OpenDraft backend');
@@ -126,9 +155,35 @@ export interface AuthResponse {
   refreshToken: string;
 }
 
+/** Returned by /login when 2FA is on and the device is new — instead of
+ *  tokens, the server gives us a challengeId and emails the user a code. */
+export interface DeviceChallengeResponse {
+  deviceVerificationRequired: true;
+  challengeId: string;
+  message?: string;
+}
+
+export type LoginResponse = AuthResponse | DeviceChallengeResponse;
+
+export function isDeviceChallenge(r: LoginResponse): r is DeviceChallengeResponse {
+  return (r as DeviceChallengeResponse).deviceVerificationRequired === true;
+}
+
 export interface CollabServerConfig {
   googleEnabled: boolean;
   emailVerificationRequired: boolean;
+}
+
+export interface DeviceRecord {
+  deviceId: string;
+  deviceName: string;
+  platform: string | null;
+  userAgent: string | null;
+  ipAddress: string | null;
+  trusted: boolean;
+  firstSeenAt: string;
+  lastSeenAt: string;
+  current: boolean;
 }
 
 // ── API methods ──
@@ -137,13 +192,20 @@ export const collabAuthApi = {
   register: (email: string, password: string, displayName: string) =>
     backendAuthRequest<AuthResponse>('/register', {
       method: 'POST',
-      body: JSON.stringify({ email, password, displayName }),
+      body: JSON.stringify({ email, password, displayName, device: getDeviceInfo() }),
     }),
 
   login: (email: string, password: string) =>
-    backendAuthRequest<AuthResponse>('/login', {
+    backendAuthRequest<LoginResponse>('/login', {
       method: 'POST',
-      body: JSON.stringify({ email, password }),
+      body: JSON.stringify({ email, password, device: getDeviceInfo() }),
+    }),
+
+  /** Confirm a new-device 2FA challenge with the emailed 6-digit code. */
+  verifyDevice: (challengeId: string, code: string) =>
+    backendAuthRequest<AuthResponse>('/verify-device', {
+      method: 'POST',
+      body: JSON.stringify({ challengeId, code }),
     }),
 
   refresh: (refreshToken: string) =>
@@ -181,8 +243,47 @@ export const collabAuthApi = {
   loginWithGoogle: (idToken: string) =>
     backendAuthRequest<AuthResponse>('/google', {
       method: 'POST',
-      body: JSON.stringify({ idToken }),
+      body: JSON.stringify({ idToken, device: getDeviceInfo() }),
     }),
+
+  /** Change the password for the authenticated user. Server also revokes
+   *  every refresh token, so the client must re-login afterwards. */
+  changePassword: (currentPassword: string, newPassword: string) =>
+    backendAuthedRequest<{ message: string }>('/change-password', {
+      method: 'POST',
+      body: JSON.stringify({ currentPassword, newPassword }),
+    }),
+
+  setTwoFactorEnabled: (enabled: boolean) =>
+    backendAuthedRequest<{ user: CollabUser }>('/two-factor', {
+      method: 'POST',
+      body: JSON.stringify({ enabled }),
+    }),
+
+  listDevices: () =>
+    backendAuthedRequest<{ devices: DeviceRecord[] }>('/devices')
+      .then((r) => r.devices),
+
+  revokeDevice: (deviceId: string) =>
+    backendAuthedRequest<{ message: string }>(
+      `/devices/${encodeURIComponent(deviceId)}`,
+      { method: 'DELETE' },
+    ),
+
+  /** Permanently delete the authenticated user's account (Apple Guideline 5.1.1(v)).
+   *  For password accounts, supply the current password; for Google-only
+   *  accounts, supply confirmation: 'DELETE'. After this returns 200 the
+   *  caller MUST clear local auth state — the access token still references
+   *  a user that no longer exists. */
+  deleteAccount: async (opts: { password?: string; confirmation?: string }) => {
+    const res = await backendAuthRequestRaw('/account', {
+      method: 'DELETE',
+      headers: { Authorization: `Bearer ${useSettingsStore.getState().collabAuth.accessToken ?? ''}` },
+      body: JSON.stringify(opts),
+    });
+    if (!res.ok) throw await parseError(res, 'Auth');
+    return res.json() as Promise<{ message: string }>;
+  },
 
   getMe: () =>
     backendAuthedRequest<CollabUser>('/me'),

--- a/frontend/src/services/deviceId.ts
+++ b/frontend/src/services/deviceId.ts
@@ -1,0 +1,112 @@
+/**
+ * Stable per-installation device identifier sent on every auth request.
+ *
+ * The server uses (userId, deviceId) to:
+ *   • notify the user by email when a new device signs in (default), or
+ *   • require an emailed 6-digit code on every new device when the user
+ *     has opted into two-factor verification.
+ *
+ * The id is generated once on first run and persisted in localStorage.
+ * Clearing site data effectively forgets the device — that's by design;
+ * a cleared client looks new to the server and the user gets notified.
+ */
+
+const STORAGE_KEY = 'opendraft:deviceId';
+const NAME_KEY = 'opendraft:deviceName';
+
+function randomId(): string {
+  // crypto.randomUUID is available everywhere we ship (modern browsers,
+  // Tauri's WKWebView, Android System WebView). The fallback only kicks
+  // in for very old environments and is not security-critical — the id
+  // is opaque to the user and rotated freely.
+  try {
+    if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+      return crypto.randomUUID();
+    }
+  } catch { /* ignore */ }
+  return `dev-${Math.random().toString(36).slice(2)}-${Date.now().toString(36)}`;
+}
+
+function detectPlatform(): string {
+  try {
+    const ua = navigator.userAgent || '';
+    const isTauri = typeof (window as any).__TAURI__ !== 'undefined' || typeof (window as any).__TAURI_INTERNALS__ !== 'undefined';
+    if (isTauri) {
+      if (/Android/i.test(ua)) return 'Android (OpenDraft)';
+      if (/iPhone|iPad|iPod/i.test(ua)) return 'iOS (OpenDraft)';
+      if (/Macintosh|Mac OS X/i.test(ua)) return 'macOS (OpenDraft)';
+      if (/Windows/i.test(ua)) return 'Windows (OpenDraft)';
+      if (/Linux/i.test(ua)) return 'Linux (OpenDraft)';
+      return 'Desktop (OpenDraft)';
+    }
+    if (/Android/i.test(ua)) return 'Android browser';
+    if (/iPhone|iPad|iPod/i.test(ua)) return 'iOS browser';
+    if (/Macintosh|Mac OS X/i.test(ua)) return 'macOS browser';
+    if (/Windows/i.test(ua)) return 'Windows browser';
+    if (/Linux/i.test(ua)) return 'Linux browser';
+  } catch { /* ignore */ }
+  return 'Unknown';
+}
+
+function defaultName(): string {
+  const platform = detectPlatform();
+  // Browser name as a coarse hint — better than "Unknown".
+  let browser = '';
+  try {
+    const ua = navigator.userAgent || '';
+    if (/Edg\//.test(ua)) browser = 'Edge';
+    else if (/Chrome\//.test(ua)) browser = 'Chrome';
+    else if (/Safari\//.test(ua) && !/Chrome\//.test(ua)) browser = 'Safari';
+    else if (/Firefox\//.test(ua)) browser = 'Firefox';
+  } catch { /* ignore */ }
+  return browser ? `${platform} · ${browser}` : platform;
+}
+
+export function getDeviceId(): string {
+  try {
+    const cached = localStorage.getItem(STORAGE_KEY);
+    if (cached) return cached;
+    const fresh = randomId();
+    localStorage.setItem(STORAGE_KEY, fresh);
+    return fresh;
+  } catch {
+    // Private mode / disabled storage — fall back to an in-memory id.
+    if (!(globalThis as any).__opendraftDeviceIdMemo) {
+      (globalThis as any).__opendraftDeviceIdMemo = randomId();
+    }
+    return (globalThis as any).__opendraftDeviceIdMemo;
+  }
+}
+
+export function getDeviceName(): string {
+  try {
+    const cached = localStorage.getItem(NAME_KEY);
+    if (cached) return cached;
+  } catch { /* ignore */ }
+  return defaultName();
+}
+
+export function setDeviceName(name: string): void {
+  try {
+    if (name) localStorage.setItem(NAME_KEY, name);
+    else localStorage.removeItem(NAME_KEY);
+  } catch { /* ignore */ }
+}
+
+export function getDevicePlatform(): string {
+  return detectPlatform();
+}
+
+export interface DeviceInfo {
+  deviceId: string;
+  deviceName: string;
+  platform: string;
+}
+
+export function getDeviceInfo(): DeviceInfo {
+  return {
+    deviceId: getDeviceId(),
+    deviceName: getDeviceName(),
+    platform: getDevicePlatform(),
+  };
+}

--- a/frontend/src/stores/settingsStore.ts
+++ b/frontend/src/stores/settingsStore.ts
@@ -5,6 +5,9 @@ export interface CollabUser {
   email: string;
   displayName: string;
   emailVerified: boolean;
+  /** Optional — only present from the collab server; the backend's lighter
+   *  /api/auth/me payload omits it. Defaults to false when missing. */
+  twoFactorEnabled?: boolean;
 }
 
 export interface CollabAuth {

--- a/frontend/src/styles/screenplay.css
+++ b/frontend/src/styles/screenplay.css
@@ -10166,6 +10166,98 @@ div[data-type="cast-list"].is-empty::before { content: 'Cast...'; color: #ccc; p
   background: var(--fd-toolbar-hover);
 }
 
+/* ============ ACCOUNT & SECURITY ============ */
+.settings-account-block {
+  border-top: 1px solid var(--fd-border);
+  padding: 16px 0;
+}
+.settings-account-block:first-child { border-top: none; padding-top: 0; }
+.settings-account-row {
+  display: flex;
+  align-items: flex-start;
+  gap: 16px;
+  justify-content: space-between;
+  margin-bottom: 12px;
+}
+.settings-account-title {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--fd-text);
+  margin-bottom: 4px;
+}
+.settings-account-hint {
+  font-size: 12px;
+  color: var(--fd-text-secondary, #999);
+  line-height: 1.5;
+  margin-bottom: 8px;
+}
+.settings-account-danger { border-top-color: rgba(255,68,68,0.4); }
+
+.settings-switch {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+  color: var(--fd-text);
+}
+.settings-switch input[type="checkbox"] {
+  width: 16px;
+  height: 16px;
+}
+
+.settings-device-list {
+  list-style: none;
+  margin: 8px 0 0;
+  padding: 0;
+}
+.settings-device-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 10px 12px;
+  border: 1px solid var(--fd-border);
+  border-radius: 6px;
+  margin-bottom: 8px;
+  background: var(--fd-toolbar-bg, transparent);
+}
+.settings-device-info { min-width: 0; flex: 1; }
+.settings-device-name {
+  font-weight: 600;
+  font-size: 13px;
+  color: var(--fd-text);
+  word-break: break-word;
+}
+.settings-device-current {
+  color: var(--fd-accent, #4a9eff);
+  font-weight: 500;
+  font-size: 12px;
+}
+.settings-device-meta {
+  font-size: 11px;
+  color: var(--fd-text-secondary, #999);
+  word-break: break-word;
+}
+
+.settings-delete-confirm {
+  margin-top: 12px;
+  padding: 12px;
+  border: 1px solid rgba(255,68,68,0.4);
+  border-radius: 6px;
+  background: rgba(255,68,68,0.05);
+}
+.settings-delete-warning {
+  font-size: 12px;
+  color: var(--fd-text);
+  line-height: 1.6;
+  margin-bottom: 12px;
+}
+.settings-delete-warning a {
+  color: var(--fd-accent, #4a9eff);
+  text-decoration: underline;
+  word-break: break-all;
+}
+
 /* ============ CUSTOM ELEMENT ============ */
 .custom-element { }
 


### PR DESCRIPTION
Addresses Apple Guideline 5.1.1(v) — adds in-app account deletion — plus
review feedback for password rotation, new-device awareness, and device
management.

Server (collab-server)
- DELETE /auth/account: password (or typed DELETE for Google-only) confirmed
  permanent deletion of users, refresh tokens, devices, email codes; sends
  account-deleted email; collab-session ownership rows are soft-disabled and
  audit log rows are anonymized.
- POST /auth/change-password: re-verifies the current password, rotates to
  the new one, revokes every refresh token so other devices re-auth.
- Device tracking: each client sends a stable deviceId/deviceName/platform.
  First sighting of a (user, device) pair sends a "new device signed in"
  email when 2FA is off (default). When 2FA is on, login returns a challenge
  and an emailed 6-digit code is required via POST /auth/verify-device.
- POST /auth/two-factor: per-user opt-in toggle for the new-device gate.
- GET /auth/devices and DELETE /auth/devices/:id list and revoke active
  devices (revoking also revokes refresh tokens bound to that device).
- Schema: new user_devices, device_challenges tables; refresh_tokens.device_id
  and users.two_factor_enabled added with idempotent ALTER migrations.

Backend (Python proxy)
- Forwards X-Device-Id and proxies the new endpoints.
- DELETE /api/auth/account also wipes the user's per-user projects directory
  on success so cloud screenplays do not survive the account.

Frontend
- Settings → Account & Security: change password, 2FA toggle, active devices
  list with revoke, and a destructive Delete Account flow that first counts
  the user's cloud projects/screenplays and warns them to download anything
  they care about (per the App Review guidance).
- Login dialogs handle the device-challenge response and prompt the user for
  the emailed code instead of issuing tokens.