### PR TITLE
editor: disable native browser spellcheck so custom right-click menu works on Windows

### DIFF
--- a/frontend/src/components/ScreenplayEditor.tsx
+++ b/frontend/src/components/ScreenplayEditor.tsx
@@ -1352,7 +1352,7 @@ const ScreenplayEditor: React.FC = () => {
       : (urlScriptId || urlCommitHash) ? undefined : { type: 'doc', content: [{ type: 'action', content: [] }] },
     editable: !isHistoryMode && !(collabMode && collabRole === 'viewer'),
     editorProps: {
-      attributes: { class: `screenplay-content${isHistoryMode ? ' history-readonly' : ''}`, spellcheck: isHistoryMode ? 'false' : 'true' },
+      attributes: { class: `screenplay-content${isHistoryMode ? ' history-readonly' : ''}`, spellcheck: 'false' },
     },
     onSelectionUpdate: ({ editor: ed }) => {
       // Check custom element first


### PR DESCRIPTION
WebView2 (Edge Chromium) on Windows hijacks contextmenu on words it
considers misspelled to show its own native suggestion menu, which
prevents OpenDraft's ScriptContextMenu from appearing. We already render
our own red-squiggle decorations and suggestions via typo-js, so the
native checker is redundant and harmful — turn it off unconditionally.

https://claude.ai/code/session_01PV8RgwtT2b9UjQYLwUzKA8