### PR TITLE
auth: add forgot-password / reset-password flow

### DIFF
--- a/backend/app/api/auth.py
+++ b/backend/app/api/auth.py
@@ -161,6 +161,19 @@ async def change_password(request: Request) -> Response:
     return await _proxy(request, "POST", "change-password")
 
 
+@router.post("/forgot-password")
+async def forgot_password(request: Request) -> Response:
+    """Request a password-reset email. Always returns a generic message so
+    callers can't enumerate registered email addresses."""
+    return await _proxy(request, "POST", "forgot-password")
+
+
+@router.post("/reset-password")
+async def reset_password(request: Request) -> Response:
+    """Consume a reset token + set the new password."""
+    return await _proxy(request, "POST", "reset-password")
+
+
 @router.post("/two-factor")
 async def toggle_two_factor(request: Request) -> Response:
     return await _proxy(request, "POST", "two-factor")

--- a/collab-server/src/db.ts
+++ b/collab-server/src/db.ts
@@ -63,6 +63,16 @@ export interface DeviceChallengeRow {
   created_at: string;
 }
 
+export interface PasswordResetRow {
+  id: string;
+  user_id: string;
+  token_hash: string;
+  expires_at: string;
+  used: number;
+  created_at: string;
+  ip_address: string | null;
+}
+
 export interface CollabSessionRow {
   token: string;
   project_id: string;
@@ -147,6 +157,16 @@ const SCHEMA_SQL = `
     created_at TEXT NOT NULL
   );
 
+  CREATE TABLE IF NOT EXISTS password_resets (
+    id TEXT PRIMARY KEY,
+    user_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    token_hash TEXT NOT NULL,
+    expires_at TEXT NOT NULL,
+    used INTEGER DEFAULT 0,
+    created_at TEXT NOT NULL,
+    ip_address TEXT
+  );
+
   CREATE TABLE IF NOT EXISTS audit_log (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     user_id TEXT,
@@ -182,6 +202,10 @@ const SCHEMA_SQL = `
     ON user_devices(user_id, device_id);
   CREATE INDEX IF NOT EXISTS idx_device_challenges_user_device
     ON device_challenges(user_id, device_id);
+  CREATE INDEX IF NOT EXISTS idx_password_resets_user
+    ON password_resets(user_id);
+  CREATE INDEX IF NOT EXISTS idx_password_resets_expires
+    ON password_resets(expires_at);
 `;
 
 export async function initDB(): Promise<DBAdapter> {

--- a/collab-server/src/routes/auth.ts
+++ b/collab-server/src/routes/auth.ts
@@ -7,6 +7,7 @@ import * as tokenService from '../services/tokenService';
 import * as emailService from '../services/emailService';
 import * as auditService from '../services/auditService';
 import * as deviceService from '../services/deviceService';
+import * as passwordResetService from '../services/passwordResetService';
 import type { DeviceInfo } from '../services/deviceService';
 import { requireAuth } from '../middleware/auth';
 import { strictLimiter, veryStrictLimiter } from '../middleware/rateLimit';
@@ -69,6 +70,16 @@ const resendDeviceChallengeSchema = z.object({
 
 const changePasswordSchema = z.object({
   currentPassword: z.string().min(1),
+  newPassword: passwordRule,
+});
+
+const forgotPasswordSchema = z.object({
+  email: z.string().email().max(255),
+});
+
+const resetPasswordSchema = z.object({
+  // The token is base64url-encoded 32 random bytes (~43 chars). Cap generously.
+  token: z.string().min(16).max(256),
   newPassword: passwordRule,
 });
 
@@ -644,9 +655,9 @@ router.post('/change-password', requireAuth, veryStrictLimiter, async (req, res)
     }
 
     if (!user.password_hash) {
-      // Google-only account: no password to change. Asks the user to set one
-      // by signing out and using "Forgot password" — which we don't have yet,
-      // so this is a hard error for now.
+      // Google-only account: no password to change. The user can set one by
+      // signing out and going through the "Forgot password" flow, which
+      // accepts a Google-linked account and writes a password_hash.
       res.status(400).json({ error: 'This account does not use a password (signed in with Google).' });
       return;
     }
@@ -682,6 +693,132 @@ router.post('/change-password', requireAuth, veryStrictLimiter, async (req, res)
     res.json({ message: 'Password updated. Please sign in again on all devices.' });
   } catch (err) {
     console.error('Change password error:', err);
+    res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+// ── Forgot password / reset password ──
+//
+// The flow is:
+//   1. User submits their email to /forgot-password. Server generates a
+//      single-use token, stores its bcrypt hash, and emails the user a link
+//      containing the raw token. The response is intentionally generic —
+//      "if an account exists, an email was sent" — to avoid leaking which
+//      addresses are registered.
+//   2. User opens the link in the frontend, which collects a new password
+//      and POSTs it with the token to /reset-password. Server validates,
+//      updates password_hash, invalidates every refresh token, and emails a
+//      "your password was changed" notice. Google-only accounts can use this
+//      flow to *set* an initial password (the email itself is proof of
+//      identity).
+//
+// Both endpoints require outbound SMTP — without it the email never reaches
+// the user and the flow stalls, so we return a clear error.
+
+router.post('/forgot-password', veryStrictLimiter, async (req, res) => {
+  try {
+    const parsed = forgotPasswordSchema.safeParse(req.body);
+    if (!parsed.success) {
+      res.status(400).json({ error: 'Invalid input' });
+      return;
+    }
+
+    if (!config.smtpHost) {
+      res.status(503).json({
+        error:
+          'Password reset is unavailable: this server has no email service configured. ' +
+          'Contact the administrator.',
+      });
+      return;
+    }
+
+    const genericMessage =
+      'If an account with that email exists, a password-reset link was sent to it. ' +
+      'The link expires in 30 minutes.';
+
+    const user = await userService.findUserByEmail(parsed.data.email);
+    if (user) {
+      const created = await passwordResetService.createResetToken(user.id, getClientIp(req));
+      try {
+        await emailService.sendPasswordResetEmail(user.email, created.token, getClientIp(req));
+      } catch (err) {
+        // Log but do not surface — keeps the response identical for valid
+        // and invalid email enumeration attempts.
+        console.error('Failed to send password reset email:', err);
+      }
+      await auditService.logEvent(
+        'password_reset_requested',
+        user.id,
+        null,
+        { email: user.email },
+        getClientIp(req),
+      );
+    } else {
+      await auditService.logEvent(
+        'password_reset_requested',
+        null,
+        null,
+        { email: parsed.data.email, reason: 'user_not_found' },
+        getClientIp(req),
+      );
+    }
+
+    // Always respond identically so callers can't enumerate registered emails.
+    res.json({ message: genericMessage });
+  } catch (err) {
+    console.error('Forgot password error:', err);
+    res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+router.post('/reset-password', veryStrictLimiter, async (req, res) => {
+  try {
+    const parsed = resetPasswordSchema.safeParse(req.body);
+    if (!parsed.success) {
+      res.status(400).json({ error: 'Invalid input', details: parsed.error.flatten().fieldErrors });
+      return;
+    }
+
+    const userId = await passwordResetService.consumeResetToken(parsed.data.token);
+    if (!userId) {
+      await auditService.logEvent(
+        'password_reset_failed',
+        null,
+        null,
+        { reason: 'invalid_or_expired_token' },
+        getClientIp(req),
+      );
+      res.status(400).json({ error: 'Invalid or expired reset link. Request a new one.' });
+      return;
+    }
+
+    const user = await userService.findUserById(userId);
+    if (!user) {
+      res.status(400).json({ error: 'Invalid or expired reset link. Request a new one.' });
+      return;
+    }
+
+    await userService.updatePassword(user.id, parsed.data.newPassword);
+    // Treat email-verified once they've proven control of the address by
+    // clicking the link — same logic as the magic-link verify route.
+    if (!user.email_verified) {
+      await userService.setEmailVerified(user.id);
+    }
+    // Invalidate every refresh token — any device that was signed in must
+    // sign in again with the new password.
+    await tokenService.revokeAllRefreshTokens(user.id);
+
+    await auditService.logEvent('password_reset', user.id, null, null, getClientIp(req));
+
+    // Best-effort notification email.
+    const ua = typeof req.headers['user-agent'] === 'string'
+      ? req.headers['user-agent']
+      : 'Unknown device';
+    try { await emailService.sendPasswordChangedNotice(user.email, ua); } catch { /* ignore */ }
+
+    res.json({ message: 'Password updated. You can now sign in with your new password.' });
+  } catch (err) {
+    console.error('Reset password error:', err);
     res.status(500).json({ error: 'Internal server error' });
   }
 });

--- a/collab-server/src/services/auditService.ts
+++ b/collab-server/src/services/auditService.ts
@@ -16,6 +16,9 @@ export type AuditAction =
   | 'new_device_challenge_resend'
   | 'new_device_verified'
   | 'password_changed'
+  | 'password_reset_requested'
+  | 'password_reset_failed'
+  | 'password_reset'
   | 'account_deleted'
   | 'device_revoked';
 

--- a/collab-server/src/services/emailService.ts
+++ b/collab-server/src/services/emailService.ts
@@ -177,6 +177,50 @@ export async function sendNewDeviceNotice(
   });
 }
 
+export async function sendPasswordResetEmail(
+  email: string,
+  token: string,
+  ipAddress: string | null,
+): Promise<void> {
+  // The link carries only the opaque token — the server looks the user up by
+  // matching it against stored hashes. No email is in the URL.
+  const resetLink = `${config.appUrl}/reset-password?token=${encodeURIComponent(token)}`;
+  const ipLine = ipAddress ? `\nRequested from IP: ${ipAddress}` : '';
+
+  const transport = getTransporter();
+  if (!transport) {
+    console.log(`[Email] SMTP not configured. Password reset link for ${email}: ${resetLink}`);
+    return;
+  }
+
+  await transport.sendMail({
+    from: config.smtpFrom,
+    to: email,
+    subject: 'OpenDraft - Reset your password',
+    text:
+      `Someone requested a password reset for your OpenDraft account.${ipLine}\n\n` +
+      `If this was you, click the link below to choose a new password. The link expires in 30 minutes:\n\n${resetLink}\n\n` +
+      `If you did not request this, you can safely ignore this email — your password will not change.`,
+    html: `
+      <div style="font-family: sans-serif; max-width: 440px; margin: 0 auto; padding: 20px;">
+        <h2 style="color: #333;">Reset your OpenDraft password</h2>
+        <p>Someone requested a password reset for your OpenDraft account.</p>
+        ${ipAddress ? `<p style="color: #666; font-size: 13px;">Requested from IP: ${ipAddress}</p>` : ''}
+        <p>If this was you, click the button below to choose a new password:</p>
+        <p style="text-align: center; margin: 20px 0;">
+          <a href="${resetLink}" style="display: inline-block; background: #4a6fa5; color: #fff; text-decoration: none; padding: 12px 24px; border-radius: 6px; font-weight: 600;">Reset password</a>
+        </p>
+        <p style="color: #666; font-size: 13px;">Or copy this link into your browser:<br><span style="word-break: break-all;">${resetLink}</span></p>
+        <p style="color: #666; font-size: 13px;">The link expires in 30 minutes.</p>
+        <p style="color: #b00; font-size: 13px;">
+          If you did not request this, you can safely ignore this email — your
+          password will not change.
+        </p>
+      </div>
+    `,
+  });
+}
+
 export async function sendPasswordChangedNotice(email: string, deviceName: string): Promise<void> {
   const transport = getTransporter();
   if (!transport) {

--- a/collab-server/src/services/passwordResetService.ts
+++ b/collab-server/src/services/passwordResetService.ts
@@ -1,0 +1,98 @@
+import * as crypto from 'crypto';
+import * as bcrypt from 'bcryptjs';
+import { v4 as uuidv4 } from 'uuid';
+import { getDB } from '../db';
+import type { PasswordResetRow } from '../db';
+
+const TOKEN_TTL_MINUTES = 30;
+
+export interface CreatedResetToken {
+  token: string;
+  expiresAt: string;
+}
+
+/**
+ * Generate a single-use password-reset token for the given user.
+ *
+ * The raw token is high-entropy random; only its bcrypt hash is stored, so a
+ * database leak doesn't yield working reset links. The caller emails the raw
+ * value to the user. Previous outstanding resets for the same user are
+ * invalidated so only one live link exists at a time.
+ *
+ * Per-route rate limiting (`veryStrictLimiter`) is the abuse defence; we don't
+ * cap outstanding tokens here because invalidating-on-issue already keeps the
+ * count at <= 1.
+ */
+export async function createResetToken(
+  userId: string,
+  ipAddress: string | null,
+): Promise<CreatedResetToken> {
+  const db = getDB();
+  const now = new Date();
+  const nowIso = now.toISOString();
+
+  // Invalidate any earlier outstanding resets so only one link is live.
+  await db.run(
+    'UPDATE password_resets SET used = 1 WHERE user_id = ? AND used = 0',
+    [userId],
+  );
+
+  const token = crypto.randomBytes(32).toString('base64url');
+  const tokenHash = bcrypt.hashSync(token, 10);
+  const id = uuidv4();
+  const expiresAt = new Date(now.getTime() + TOKEN_TTL_MINUTES * 60 * 1000).toISOString();
+
+  await db.run(
+    `INSERT INTO password_resets (id, user_id, token_hash, expires_at, used, created_at, ip_address)
+     VALUES (?, ?, ?, ?, 0, ?, ?)`,
+    [id, userId, tokenHash, expiresAt, nowIso, ipAddress],
+  );
+
+  return { token, expiresAt };
+}
+
+/**
+ * Validate a reset token and atomically mark it used. Returns the owning
+ * user_id on success, or null if the token is missing/expired/already used.
+ *
+ * We can't index on token_hash (bcrypt salts every hash), so we iterate over
+ * the live rows and bcrypt-compare — same pattern as refresh_tokens. The set
+ * is bounded by the rate limiter + per-user cap, so the cost stays small.
+ */
+export async function consumeResetToken(rawToken: string): Promise<string | null> {
+  const db = getDB();
+  const now = new Date().toISOString();
+
+  const rows = await db.all<PasswordResetRow>(
+    'SELECT * FROM password_resets WHERE used = 0 AND expires_at > ?',
+    [now],
+  );
+
+  for (const row of rows) {
+    if (bcrypt.compareSync(rawToken, row.token_hash)) {
+      // Race-safe: only succeed if the row is still unused.
+      const result = await db.run(
+        'UPDATE password_resets SET used = 1 WHERE id = ? AND used = 0',
+        [row.id],
+      );
+      if (result.changes === 0) return null;
+      return row.user_id;
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Garbage-collect expired or used reset rows older than `olderThanHours`.
+ * Not wired into a scheduler yet; kept here for an operator-triggered cron.
+ */
+export async function purgeStaleResets(olderThanHours = 24): Promise<number> {
+  const db = getDB();
+  const cutoff = new Date(Date.now() - olderThanHours * 60 * 60 * 1000).toISOString();
+  const result = await db.run(
+    'DELETE FROM password_resets WHERE expires_at < ? OR (used = 1 AND created_at < ?)',
+    [cutoff, cutoff],
+  );
+  return result.changes;
+}

--- a/collab-server/src/services/userService.ts
+++ b/collab-server/src/services/userService.ts
@@ -106,6 +106,7 @@ export async function updatePassword(userId: string, newPassword: string): Promi
 export async function deleteUser(userId: string): Promise<void> {
   const db = getDB();
   await db.run('UPDATE collab_sessions SET active = 0 WHERE created_by = ?', [userId]);
+  await db.run('DELETE FROM password_resets WHERE user_id = ?', [userId]);
   await db.run('DELETE FROM device_challenges WHERE user_id = ?', [userId]);
   await db.run('DELETE FROM user_devices WHERE user_id = ?', [userId]);
   await db.run('DELETE FROM email_verifications WHERE user_id = ?', [userId]);

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -12,6 +12,7 @@ import StorageFallbackDialog from './components/StorageFallbackDialog';
 import SaveErrorDialog from './components/SaveErrorDialog';
 import OneDriveWarningDialog from './components/OneDriveWarningDialog';
 import VerifyEmailRoute from './components/VerifyEmailRoute';
+import ResetPasswordRoute from './components/ResetPasswordRoute';
 import { pluginRegistry } from './plugins/registry';
 import './styles/screenplay.css';
 import './styles/avScript.css';
@@ -25,6 +26,7 @@ function App() {
       <Routes>
         <Route path="/" element={<ScreenplayEditor />} />
         <Route path="/verify" element={<VerifyEmailRoute />} />
+        <Route path="/reset-password" element={<ResetPasswordRoute />} />
         <Route path="/projects" element={<ProjectList />} />
         <Route path="/project/:projectId" element={<ProjectView />} />
         <Route path="/project/:projectId/edit/:scriptId" element={<ScreenplayEditor />} />

--- a/frontend/src/components/CollabLoginDialog.tsx
+++ b/frontend/src/components/CollabLoginDialog.tsx
@@ -61,6 +61,12 @@ const CollabLoginDialog: React.FC<CollabLoginDialogProps> = ({ onClose, onSucces
   const [pendingChallenge, setPendingChallenge] = useState<{ challengeId: string; email: string } | null>(null);
   const [deviceCode, setDeviceCode] = useState('');
 
+  // Forgot-password state — when the user clicks "Forgot password?" we swap
+  // the login form for an email-entry form. After submitting, we show a
+  // generic "if an account exists, an email was sent" confirmation.
+  const [forgotMode, setForgotMode] = useState<'form' | 'sent' | null>(null);
+  const [forgotEmail, setForgotEmail] = useState(savedEmail);
+
   useEffect(() => {
     // One-time migration: purge the legacy key that stored email+password in
     // plaintext. The email-only replacement is under opendraft:rememberedEmail.
@@ -161,6 +167,22 @@ const CollabLoginDialog: React.FC<CollabLoginDialogProps> = ({ onClose, onSucces
     }
   };
 
+  const handleForgotPassword = async () => {
+    if (!forgotEmail) return;
+    setLoading(true);
+    try {
+      const r = await collabAuthApi.forgotPassword(forgotEmail);
+      // Server returns the generic message regardless of whether the email
+      // is registered. Show its message verbatim — don't second-guess it.
+      showToast(r.message || 'If an account exists, a reset link was sent.', 'success');
+      setForgotMode('sent');
+    } catch (err: any) {
+      showToast(err.message || 'Could not send reset email', 'error');
+    } finally {
+      setLoading(false);
+    }
+  };
+
   const handleGoogleLogin = async () => {
     setLoading(true);
     try {
@@ -179,7 +201,8 @@ const CollabLoginDialog: React.FC<CollabLoginDialogProps> = ({ onClose, onSucces
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
     if (e.key === 'Enter') {
-      if (tab === 'login' && pendingChallenge) handleVerifyDevice();
+      if (tab === 'login' && forgotMode === 'form') handleForgotPassword();
+      else if (tab === 'login' && pendingChallenge) handleVerifyDevice();
       else if (tab === 'login') handleLogin();
       else handleRegister();
     } else if (e.key === 'Escape') {
@@ -220,20 +243,71 @@ const CollabLoginDialog: React.FC<CollabLoginDialogProps> = ({ onClose, onSucces
           <div className="settings-auth-tabs">
             <button
               className={`settings-auth-tab ${tab === 'login' ? 'active' : ''}`}
-              onClick={() => setTab('login')}
+              onClick={() => { setTab('login'); setForgotMode(null); }}
             >
               Sign In
             </button>
             <button
               className={`settings-auth-tab ${tab === 'register' ? 'active' : ''}`}
-              onClick={() => setTab('register')}
+              onClick={() => { setTab('register'); setForgotMode(null); }}
             >
               Create Account
             </button>
           </div>
 
           {tab === 'login' ? (
-            pendingChallenge ? (
+            forgotMode === 'form' ? (
+              <div className="settings-auth-form">
+                <p style={{ margin: '0 0 12px', fontSize: 13, color: 'var(--fd-text-muted)' }}>
+                  Enter the email address you used to sign up. We'll email you
+                  a link to choose a new password. The link expires in 30 minutes.
+                </p>
+                <div className="settings-field">
+                  <label>Email</label>
+                  <input
+                    className="dialog-input"
+                    type="email"
+                    value={forgotEmail}
+                    onChange={(e) => setForgotEmail(e.target.value)}
+                    placeholder="you@example.com"
+                    autoFocus
+                  />
+                </div>
+                <div style={{ display: 'flex', gap: 8 }}>
+                  <button
+                    className="dialog-btn dialog-btn-primary settings-auth-submit"
+                    onClick={handleForgotPassword}
+                    disabled={!forgotEmail || loading}
+                  >
+                    {loading ? 'Sending...' : 'Send reset link'}
+                  </button>
+                  <button
+                    className="dialog-btn"
+                    onClick={() => setForgotMode(null)}
+                    disabled={loading}
+                  >
+                    Back to sign in
+                  </button>
+                </div>
+              </div>
+            ) : forgotMode === 'sent' ? (
+              <div className="settings-auth-form">
+                <p style={{ margin: '0 0 12px', fontSize: 13 }}>
+                  If an account with <strong>{forgotEmail}</strong> exists, we've
+                  emailed it a link to choose a new password. Check your inbox
+                  (and the spam folder).
+                </p>
+                <p style={{ margin: '0 0 16px', fontSize: 13, color: 'var(--fd-text-muted)' }}>
+                  The link expires in 30 minutes. You can request a new one at any time.
+                </p>
+                <button
+                  className="dialog-btn dialog-btn-primary settings-auth-submit"
+                  onClick={() => setForgotMode(null)}
+                >
+                  Back to sign in
+                </button>
+              </div>
+            ) : pendingChallenge ? (
               <div className="settings-auth-form">
                 <p style={{ margin: '0 0 12px', fontSize: 13, color: 'var(--fd-text-muted)' }}>
                   A 6-digit verification code was emailed to <strong>{pendingChallenge.email}</strong>{' '}
@@ -307,6 +381,19 @@ const CollabLoginDialog: React.FC<CollabLoginDialogProps> = ({ onClose, onSucces
                     {showLoginPw ? <FaEyeSlash /> : <FaEye />}
                   </button>
                 </div>
+                <button
+                  type="button"
+                  className="collab-forgot-link"
+                  onClick={() => {
+                    // Carry whatever they've typed into the email field over,
+                    // so the most common case (typo'd password) needs no extra
+                    // typing in the reset form.
+                    setForgotEmail(loginEmail || savedEmail);
+                    setForgotMode('form');
+                  }}
+                >
+                  Forgot password?
+                </button>
               </div>
               <button
                 className="dialog-btn dialog-btn-primary settings-auth-submit"

--- a/frontend/src/components/ResetPasswordRoute.tsx
+++ b/frontend/src/components/ResetPasswordRoute.tsx
@@ -1,0 +1,174 @@
+/**
+ * /reset-password?token=… landing page.
+ *
+ * The forgot-password email carries a link here with an opaque token. The
+ * user picks a new password; we POST {token, newPassword} to /reset-password.
+ * On success the server has already revoked every refresh token, so we bounce
+ * the user to the app and let the normal sign-in flow take over.
+ */
+
+import React, { useState } from 'react';
+import { useNavigate, useSearchParams } from 'react-router-dom';
+import { FaEye, FaEyeSlash } from 'react-icons/fa';
+import { collabAuthApi } from '../services/collabAuth';
+import { showToast } from './Toast';
+
+type Status = 'idle' | 'submitting' | 'success' | 'error';
+
+const ResetPasswordRoute: React.FC = () => {
+  const [params] = useSearchParams();
+  const navigate = useNavigate();
+  const token = params.get('token') || '';
+
+  const [password, setPassword] = useState('');
+  const [confirm, setConfirm] = useState('');
+  const [showPw, setShowPw] = useState(false);
+  const [showConfirm, setShowConfirm] = useState(false);
+  const [status, setStatus] = useState<Status>('idle');
+  const [error, setError] = useState('');
+
+  // Missing token = the user got here via something other than the email link.
+  // We still render the form so the user can read why it's broken.
+  const missingToken = !token;
+
+  const validate = (): string | null => {
+    if (password.length < 8) return 'Password must be at least 8 characters.';
+    if (!/^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)/.test(password)) {
+      return 'Password must contain an uppercase letter, a lowercase letter, and a digit.';
+    }
+    if (password !== confirm) return 'Passwords do not match.';
+    return null;
+  };
+
+  const handleSubmit = async () => {
+    if (missingToken) return;
+    const validationError = validate();
+    if (validationError) {
+      setError(validationError);
+      return;
+    }
+    setError('');
+    setStatus('submitting');
+    try {
+      await collabAuthApi.resetPassword(token, password);
+      setStatus('success');
+      showToast('Password updated. You can sign in with your new password.', 'success');
+      setTimeout(() => navigate('/', { replace: true }), 1500);
+    } catch (err: any) {
+      setStatus('error');
+      setError(err?.message || 'Could not reset password.');
+    }
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter') handleSubmit();
+  };
+
+  return (
+    <div style={{
+      display: 'flex', alignItems: 'center', justifyContent: 'center',
+      minHeight: '70vh', padding: 24,
+    }}>
+      <div
+        style={{
+          maxWidth: 440, width: '100%', padding: 24, borderRadius: 8,
+          background: 'var(--fd-surface, #1e1e1e)',
+          color: 'var(--fd-text, #eee)',
+          boxShadow: '0 4px 24px rgba(0,0,0,0.25)',
+        }}
+        onKeyDown={handleKeyDown}
+      >
+        <h2 style={{ marginTop: 0 }}>Choose a new password</h2>
+
+        {missingToken ? (
+          <>
+            <p style={{ color: 'var(--fd-text-muted, #aaa)' }}>
+              This reset link is missing its token. Request a new password-reset
+              email from the sign-in screen.
+            </p>
+            <button
+              className="dialog-btn dialog-btn-primary"
+              onClick={() => navigate('/', { replace: true })}
+              style={{ marginTop: 12 }}
+            >
+              Go to sign in
+            </button>
+          </>
+        ) : status === 'success' ? (
+          <>
+            <p>Your password was updated. Redirecting to the sign-in screen…</p>
+          </>
+        ) : (
+          <div className="settings-auth-form">
+            <div className="settings-field">
+              <label>New Password</label>
+              <div className="password-input-wrapper">
+                <input
+                  className="dialog-input"
+                  type={showPw ? 'text' : 'password'}
+                  value={password}
+                  onChange={(e) => setPassword(e.target.value)}
+                  placeholder="Min 8 chars, upper + lower + digit"
+                  autoFocus
+                  disabled={status === 'submitting'}
+                />
+                <button
+                  type="button"
+                  className="password-toggle-btn"
+                  onClick={() => setShowPw(!showPw)}
+                  tabIndex={-1}
+                  aria-label={showPw ? 'Hide password' : 'Show password'}
+                >
+                  {showPw ? <FaEyeSlash /> : <FaEye />}
+                </button>
+              </div>
+            </div>
+            <div className="settings-field">
+              <label>Confirm Password</label>
+              <div className="password-input-wrapper">
+                <input
+                  className="dialog-input"
+                  type={showConfirm ? 'text' : 'password'}
+                  value={confirm}
+                  onChange={(e) => setConfirm(e.target.value)}
+                  placeholder="Re-enter password"
+                  disabled={status === 'submitting'}
+                />
+                <button
+                  type="button"
+                  className="password-toggle-btn"
+                  onClick={() => setShowConfirm(!showConfirm)}
+                  tabIndex={-1}
+                  aria-label={showConfirm ? 'Hide password' : 'Show password'}
+                >
+                  {showConfirm ? <FaEyeSlash /> : <FaEye />}
+                </button>
+              </div>
+            </div>
+
+            {error && (
+              <p style={{ color: '#e57373', fontSize: 13, margin: 0 }}>{error}</p>
+            )}
+
+            <button
+              className="dialog-btn dialog-btn-primary settings-auth-submit"
+              onClick={handleSubmit}
+              disabled={!password || !confirm || status === 'submitting'}
+            >
+              {status === 'submitting' ? 'Updating…' : 'Update password'}
+            </button>
+            <button
+              className="dialog-btn"
+              onClick={() => navigate('/', { replace: true })}
+              disabled={status === 'submitting'}
+            >
+              Cancel
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default ResetPasswordRoute;

--- a/frontend/src/services/collabAuth.ts
+++ b/frontend/src/services/collabAuth.ts
@@ -264,6 +264,24 @@ export const collabAuthApi = {
       body: JSON.stringify({ currentPassword, newPassword }),
     }),
 
+  /** Request a password-reset email. The server replies with a generic
+   *  "if an account exists, an email was sent" message regardless of whether
+   *  the address is registered — do not surface differently in the UI. */
+  forgotPassword: (email: string) =>
+    backendAuthRequest<{ message: string }>('/forgot-password', {
+      method: 'POST',
+      body: JSON.stringify({ email }),
+    }),
+
+  /** Consume a reset token from the emailed link and set a new password.
+   *  All refresh tokens are revoked server-side, so other devices will need
+   *  to sign in again. */
+  resetPassword: (token: string, newPassword: string) =>
+    backendAuthRequest<{ message: string }>('/reset-password', {
+      method: 'POST',
+      body: JSON.stringify({ token, newPassword }),
+    }),
+
   setTwoFactorEnabled: (enabled: boolean) =>
     backendAuthedRequest<{ user: CollabUser }>('/two-factor', {
       method: 'POST',

--- a/frontend/src/styles/screenplay.css
+++ b/frontend/src/styles/screenplay.css
@@ -9977,6 +9977,21 @@ div[data-type="cast-list"].is-empty::before { content: 'Cast...'; color: #ccc; p
   background: var(--fd-toolbar-hover);
 }
 
+.collab-forgot-link {
+  align-self: flex-end;
+  margin-top: 6px;
+  background: none;
+  border: none;
+  padding: 0;
+  font-size: 12px;
+  color: var(--fd-accent);
+  cursor: pointer;
+  text-decoration: underline;
+}
+.collab-forgot-link:hover {
+  text-decoration: none;
+}
+
 .settings-field {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
The change-password endpoint already pointed users at a "Forgot password"
flow that didn't exist — leaving Google-only accounts (and anyone who
forgot their password) with no recovery path. This wires it up end-to-end.

Server (collab-server):
  - New password_resets table; bcrypt-hashed single-use tokens, 30-min TTL,
    previous outstanding tokens invalidated when a new one is issued.
  - POST /auth/forgot-password — emails a reset link. Always returns the
    same generic message so callers can't enumerate registered addresses.
    Requires SMTP; otherwise returns 503.
  - POST /auth/reset-password — consumes the token, updates password_hash,
    marks email verified, revokes every refresh token, sends a notice email.
    Works for Google-only accounts too (lets them set an initial password).

Backend (Python):
  - Proxies the two new endpoints to the collab server.

Frontend:
  - "Forgot password?" link under the login password field; opens an
    in-dialog email-entry view, then a confirmation view.
  - New /reset-password route with new + confirm password fields.