### PR TITLE
Refresh active template CSS when formatting templates change

### DIFF
--- a/frontend/src/components/ScreenplayEditor.tsx
+++ b/frontend/src/components/ScreenplayEditor.tsx
@@ -1447,6 +1447,7 @@ const ScreenplayEditor: React.FC = () => {
   // ── Dynamic CSS injection for custom formatting templates ──
   const activeTemplateId = useFormattingTemplateStore((s) => s.activeTemplateId);
   const templatesLoaded = useFormattingTemplateStore((s) => s.loaded);
+  const templates = useFormattingTemplateStore((s) => s.templates);
 
   useEffect(() => {
     // Load templates on mount
@@ -1460,12 +1461,11 @@ const ScreenplayEditor: React.FC = () => {
       injectTemplateCss(null);
       return;
     }
-    const pageLayout = useEditorStore.getState().pageLayout;
     const css = generateTemplateCss(template, pageLayout);
     injectTemplateCss(css);
 
     return () => { injectTemplateCss(null); };
-  }, [activeTemplateId, templatesLoaded]);
+  }, [activeTemplateId, templatesLoaded, templates, pageLayout]);
 
   // ── Owner starts collaboration — save current content, create own token, switch to collab mode ──
   const handleStartCollab = useCallback(async (guestSession: import('../services/api').CollabSession) => {


### PR DESCRIPTION
## What does this PR do?

Refreshes the generated screenplay formatting-template CSS when template data changes, not only when the active template id changes. This fixes the case where edits to the active formatting template are saved but the editor continues showing stale styling until the user switches templates or reopens the editor.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring (no functional change)
- [ ] Documentation
- [ ] Other (describe below)

## How was this tested?

- Ran `npm run build` from `frontend/`
- Ran the app locally with `npm run dev` and verified that editing an active custom template updates the injected `#opendraft-template-css` rules immediately, without switching templates

## Screenshots (if applicable)

Not applicable; this changes when generated template CSS refreshes, not the default UI appearance.

## Checklist

- [x] I've read the [Contributing Guide](docs/CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I've tested my changes locally
- [x] I've updated documentation if needed

Documentation updates are not needed for this bug fix.