### PR TITLE
Support hard breaks in the screenplay editor

### DIFF
--- a/frontend/src/components/ScreenplayEditor.tsx
+++ b/frontend/src/components/ScreenplayEditor.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useCallback, useRef, useState, useMemo } from 'react'
 import { useEditor, EditorContent } from '@tiptap/react';
 import Document from '@tiptap/extension-document';
 import Text from '@tiptap/extension-text';
+import HardBreak from '@tiptap/extension-hard-break';
 import Bold from '@tiptap/extension-bold';
 import Italic from '@tiptap/extension-italic';
 import Underline from '@tiptap/extension-underline';
@@ -1348,7 +1349,7 @@ const ScreenplayEditor: React.FC = () => {
       Document.extend({
         content: 'block+',
       }),
-      Text, Bold, Italic, Underline, Strike, Dropcursor, Gapcursor,
+      Text, HardBreak, Bold, Italic, Underline, Strike, Dropcursor, Gapcursor,
       Subscript, Superscript,
       Highlight.configure({ multicolor: true }),
       TextStyle, Color, FontFamily, FontSize,

--- a/frontend/src/editor/extensions/Action.ts
+++ b/frontend/src/editor/extensions/Action.ts
@@ -3,7 +3,7 @@ import { Node, mergeAttributes } from '@tiptap/core';
 export const Action = Node.create({
   name: 'action',
   group: 'block',
-  content: 'text*',
+  content: 'inline*',
   defining: true,
 
   parseHTML() {

--- a/frontend/src/editor/extensions/CastList.ts
+++ b/frontend/src/editor/extensions/CastList.ts
@@ -3,7 +3,7 @@ import { Node, mergeAttributes } from '@tiptap/core';
 export const CastList = Node.create({
   name: 'castList',
   group: 'block',
-  content: 'text*',
+  content: 'inline*',
   defining: true,
 
   parseHTML() {

--- a/frontend/src/editor/extensions/Character.ts
+++ b/frontend/src/editor/extensions/Character.ts
@@ -3,7 +3,7 @@ import { Node, mergeAttributes } from '@tiptap/core';
 export const Character = Node.create({
   name: 'character',
   group: 'block',
-  content: 'text*',
+  content: 'inline*',
   defining: true,
 
   addAttributes() {

--- a/frontend/src/editor/extensions/CustomElement.ts
+++ b/frontend/src/editor/extensions/CustomElement.ts
@@ -22,7 +22,7 @@ declare module '@tiptap/core' {
 export const CustomElement = Node.create<CustomElementOptions>({
   name: 'customElement',
   group: 'block',
-  content: 'text*',
+  content: 'inline*',
   defining: true,
 
   addAttributes() {

--- a/frontend/src/editor/extensions/Dialogue.ts
+++ b/frontend/src/editor/extensions/Dialogue.ts
@@ -3,7 +3,7 @@ import { Node, mergeAttributes } from '@tiptap/core';
 export const Dialogue = Node.create({
   name: 'dialogue',
   group: 'block',
-  content: 'text*',
+  content: 'inline*',
   defining: true,
 
   addAttributes() {

--- a/frontend/src/editor/extensions/EndOfAct.ts
+++ b/frontend/src/editor/extensions/EndOfAct.ts
@@ -7,7 +7,7 @@ import { Node, mergeAttributes } from '@tiptap/core';
 export const EndOfAct = Node.create({
   name: 'endOfAct',
   group: 'block',
-  content: 'text*',
+  content: 'inline*',
   defining: true,
 
   addAttributes() {

--- a/frontend/src/editor/extensions/General.ts
+++ b/frontend/src/editor/extensions/General.ts
@@ -3,7 +3,7 @@ import { Node, mergeAttributes } from '@tiptap/core';
 export const General = Node.create({
   name: 'general',
   group: 'block',
-  content: 'text*',
+  content: 'inline*',
   defining: true,
 
   parseHTML() {

--- a/frontend/src/editor/extensions/Lyrics.ts
+++ b/frontend/src/editor/extensions/Lyrics.ts
@@ -3,7 +3,7 @@ import { Node, mergeAttributes } from '@tiptap/core';
 export const Lyrics = Node.create({
   name: 'lyrics',
   group: 'block',
-  content: 'text*',
+  content: 'inline*',
   defining: true,
 
   parseHTML() {

--- a/frontend/src/editor/extensions/NewAct.ts
+++ b/frontend/src/editor/extensions/NewAct.ts
@@ -8,7 +8,7 @@ import { Node, mergeAttributes } from '@tiptap/core';
 export const NewAct = Node.create({
   name: 'newAct',
   group: 'block',
-  content: 'text*',
+  content: 'inline*',
   defining: true,
 
   addAttributes() {

--- a/frontend/src/editor/extensions/Parenthetical.ts
+++ b/frontend/src/editor/extensions/Parenthetical.ts
@@ -3,7 +3,7 @@ import { Node, mergeAttributes } from '@tiptap/core';
 export const Parenthetical = Node.create({
   name: 'parenthetical',
   group: 'block',
-  content: 'text*',
+  content: 'inline*',
   defining: true,
 
   addAttributes() {

--- a/frontend/src/editor/extensions/SceneHeading.ts
+++ b/frontend/src/editor/extensions/SceneHeading.ts
@@ -3,7 +3,7 @@ import { Node, mergeAttributes } from '@tiptap/core';
 export const SceneHeading = Node.create({
   name: 'sceneHeading',
   group: 'block',
-  content: 'text*',
+  content: 'inline*',
   defining: true,
 
   addAttributes() {

--- a/frontend/src/editor/extensions/Shot.ts
+++ b/frontend/src/editor/extensions/Shot.ts
@@ -3,7 +3,7 @@ import { Node, mergeAttributes } from '@tiptap/core';
 export const Shot = Node.create({
   name: 'shot',
   group: 'block',
-  content: 'text*',
+  content: 'inline*',
   defining: true,
 
   parseHTML() {

--- a/frontend/src/editor/extensions/ShowEpisode.ts
+++ b/frontend/src/editor/extensions/ShowEpisode.ts
@@ -3,7 +3,7 @@ import { Node, mergeAttributes } from '@tiptap/core';
 export const ShowEpisode = Node.create({
   name: 'showEpisode',
   group: 'block',
-  content: 'text*',
+  content: 'inline*',
   defining: true,
 
   parseHTML() {

--- a/frontend/src/editor/extensions/TitlePage.ts
+++ b/frontend/src/editor/extensions/TitlePage.ts
@@ -19,7 +19,7 @@ export interface TitlePageAttrs {
 export const TitlePage = Node.create({
   name: 'titlePage',
   group: 'block',
-  content: 'text*',
+  content: 'inline*',
   defining: true,
 
   addAttributes() {

--- a/frontend/src/editor/extensions/Transition.ts
+++ b/frontend/src/editor/extensions/Transition.ts
@@ -3,7 +3,7 @@ import { Node, mergeAttributes } from '@tiptap/core';
 export const Transition = Node.create({
   name: 'transition',
   group: 'block',
-  content: 'text*',
+  content: 'inline*',
   defining: true,
 
   parseHTML() {


### PR DESCRIPTION
## What does this PR do?

Adds TipTap's existing HardBreak extension to the screenplay editor and allows text-bearing screenplay elements to contain inline nodes. This enables inline hard breaks via Shift+Enter and Mod+Enter inside screenplay elements instead of forcing a new screenplay block with that block's spacing.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactoring (no functional change)
- [ ] Documentation
- [ ] Other (describe below)

## How was this tested?

- Ran `npm run build` from `frontend/`
- Ran the app locally with `npm run dev` and verified `Shift+Enter` creates `Line one<br>Line two` inside one action block
- Ran the app locally with `npm run dev` and verified `Mod+Enter` creates `Command one<br>Command two` inside one action block

## Screenshots (if applicable)

Not applicable; this is an editor keyboard behavior change.

## Checklist

- [x] I've read the [Contributing Guide](docs/CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I've tested my changes locally
- [x] I've updated documentation if needed

Documentation updates are not needed for this small editor behavior addition.