### PR TITLE
Add Arial as a system font option

### DIFF
--- a/frontend/src/utils/fonts.ts
+++ b/frontend/src/utils/fonts.ts
@@ -20,6 +20,7 @@ export const FONT_REGISTRY: FontEntry[] = [
   // Screenplay Standard
   { name: 'Courier Prime', category: 'Screenplay Standard', scripts: ['latin'], source: 'local', direction: 'ltr' },
   { name: 'Courier New', category: 'Screenplay Standard', scripts: ['latin'], source: 'system', direction: 'ltr' },
+  { name: 'Arial', category: 'Screenplay Standard', scripts: ['latin'], source: 'system', direction: 'ltr' },
 
   // Latin Extended
   { name: 'Noto Sans', category: 'Latin Extended', scripts: ['latin', 'cyrillic', 'greek'], source: 'google', direction: 'ltr' },


### PR DESCRIPTION
## What does this PR do?

Adds Arial to the font registry as a selectable system font. This exposes Arial in the application's font picker without bundling any font files.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactoring (no functional change)
- [ ] Documentation
- [ ] Other (describe below)

## How was this tested?

- Ran `npm run build` from `frontend/`
- Ran the app locally with `npm run dev` and verified Arial appears in the font picker

## Screenshots (if applicable)

Not included; this is a one-entry font registry addition.

## Checklist

- [x] I've read the [Contributing Guide](docs/CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I've tested my changes locally
- [x] I've updated documentation if needed

Documentation updates are not needed for this font registry addition.