### PR TITLE
Fix pasting on iPad: Fountain parsing and pasted fonts

### DIFF
--- a/frontend/src/components/ScreenplayEditor.tsx
+++ b/frontend/src/components/ScreenplayEditor.tsx
@@ -23,7 +23,7 @@ import { HocuspocusProvider } from '@hocuspocus/provider';
 import {
   SceneHeading, Action, Character, Dialogue, Parenthetical,
   Transition, General, Shot, NewAct, EndOfAct, Lyrics,
-  ShowEpisode, CastList, FontSize, ScriptNoteMark, TagMark,
+  ShowEpisode, CastList, FontSize, PasteFormatting, ScriptNoteMark, TagMark,
   FormatOverride, CustomElement, DualDialogue, DualDialogueColumn,
   TitlePage,
   AvBlock, AvRow, AvCell, AvPara, AvShot, AvDirection, AvKeymap,
@@ -1421,7 +1421,7 @@ const ScreenplayEditor: React.FC = () => {
       Bold, Italic, Underline, Strike, Dropcursor, Gapcursor,
       Subscript, Superscript,
       Highlight.configure({ multicolor: true }),
-      TextStyle, Color, FontFamily, FontSize,
+      TextStyle, Color, FontFamily, FontSize, PasteFormatting,
       FormatOverride, CustomElement, ScreenplayImage,
       // Use History in normal mode, Collaboration in collab mode
       ...(collabMode ? collabExtensions : [History.configure({ newGroupDelay: 150 })]),

--- a/frontend/src/editor/extensions/PasteFormatting.ts
+++ b/frontend/src/editor/extensions/PasteFormatting.ts
@@ -8,78 +8,96 @@
  * text ended up in a font that matched neither the source (the alias resolves
  * to whatever the web view falls back to) nor the screenplay around it.
  *
- * Stripping the font declarations before ProseMirror parses the HTML leaves the
- * pasted text with no font of its own, so it inherits the destination element's
- * — the screenplay's font and size. Emphasis is deliberately left alone: bold,
- * italic, underline and colour are the writer's meaning, not the source app's
- * house style.
+ * The fix drops the font from the parsed slice rather than from the HTML on the
+ * way in. Editing the HTML text meant a regex deciding what was markup and what
+ * was prose, and it got that wrong in both directions — body text that merely
+ * mentioned `style="…"` was deleted, a font name containing a semicolon
+ * corrupted the attribute around it. By the time ProseMirror has parsed the
+ * clipboard there is nothing to guess at: a font is a `textStyle` mark with a
+ * `fontFamily` or `fontSize` attribute, and dropping those leaves the text
+ * inheriting the destination element's font and size.
+ *
+ * Emphasis is deliberately left alone: bold, italic, underline and colour are
+ * the writer's meaning, not the source app's house style. They survive on their
+ * own marks — including emphasis written as a `font: bold 12px X` shorthand,
+ * which the browser's own CSS parsing hands to Tiptap's Bold rule as a
+ * font-weight.
  *
  * Text copied inside OpenDraft is exempt. ProseMirror stamps its own clipboard
  * HTML with `data-pm-slice`, and a font set deliberately with the toolbar has
  * to survive a copy and paste.
  */
 import { Extension } from '@tiptap/core';
+import { Fragment, Slice } from '@tiptap/pm/model';
+import type { Mark, Node as ProseMirrorNode } from '@tiptap/pm/model';
 import { Plugin, PluginKey } from '@tiptap/pm/state';
 
-/** ProseMirror's marker on clipboard HTML it wrote itself. */
-const INTERNAL_SLICE = /\sdata-pm-slice\s*=/i;
-
-/** `style="…"` / `style='…'`, capturing the declarations. */
-const STYLE_ATTR = /\sstyle\s*=\s*(?:"([^"]*)"|'([^']*)')/gi;
-
-/** The declarations that carry a font, including the `font:` shorthand. */
-const FONT_DECLARATION = /(?:^|;)\s*(?:-webkit-)?font(?:-family|-size)?\s*:[^;]*/gi;
-
-/** `face` and `size` on the deprecated `<font>` element. */
-const FONT_ELEMENT_ATTRS = /(<font\b[^>]*?)\s(?:face|size)\s*=\s*(?:"[^"]*"|'[^']*'|[^\s>]+)/gi;
+/** The `textStyle` attributes that carry a font, as opposed to a meaning. */
+const FONT_ATTRIBUTES = ['fontFamily', 'fontSize'];
 
 /**
- * Rewrite `font: bold italic 12px Georgia` as the weight and style it also
- * set, so dropping the shorthand does not quietly drop emphasis with it.
+ * ProseMirror's marker on clipboard HTML it wrote itself.
+ *
+ * Scoped to inside a tag, so that a pasted *article about* ProseMirror does not
+ * exempt itself from the rule by quoting the attribute in its prose.
  */
-function emphasisFromShorthand(declaration: string): string {
-  if (!/^\s*(?:;)?\s*(?:-webkit-)?font\s*:/i.test(declaration)) return '';
-  const kept: string[] = [];
-  if (/\b(bold|bolder|[5-9]00)\b/i.test(declaration)) kept.push('font-weight: bold');
-  if (/\b(italic|oblique)\b/i.test(declaration)) kept.push('font-style: italic');
-  return kept.length > 0 ? `;${kept.join(';')}` : '';
+const INTERNAL_SLICE = /<[^>]+\sdata-pm-slice\s*=/i;
+
+/** Was this clipboard HTML written by ProseMirror itself? */
+export function isInternalPaste(html: string): boolean {
+  return INTERNAL_SLICE.test(html);
 }
 
-function stripFontDeclarations(declarations: string): string {
-  return declarations
-    .replace(FONT_DECLARATION, (match) => emphasisFromShorthand(match))
-    .replace(/^\s*;+/, '')
-    .trim();
+/** Drop the font attributes from a `textStyle` mark, and the mark if it is then empty. */
+function withoutFont(marks: readonly Mark[]): Mark[] {
+  return marks.flatMap((mark) => {
+    if (mark.type.name !== 'textStyle') return [mark];
+    if (!FONT_ATTRIBUTES.some((attr) => mark.attrs[attr] != null)) return [mark];
+
+    const attrs = { ...mark.attrs };
+    for (const attr of FONT_ATTRIBUTES) attrs[attr] = null;
+    // A textStyle carrying nothing but a font has no reason to survive it.
+    const carriesSomethingElse = Object.values(attrs).some((value) => value != null);
+    return carriesSomethingElse ? [mark.type.create(attrs)] : [];
+  });
 }
 
-/**
- * Remove font-family and font-size from pasted HTML that came from outside
- * the editor. Returns the HTML unchanged for an internal ProseMirror slice.
- */
-export function stripPastedFonts(html: string): string {
-  if (INTERNAL_SLICE.test(html)) return html;
+function stripFonts(fragment: Fragment): Fragment {
+  const nodes: ProseMirrorNode[] = [];
+  fragment.forEach((node) => {
+    nodes.push(node.copy(stripFonts(node.content)).mark(withoutFont(node.marks)));
+  });
+  return Fragment.fromArray(nodes);
+}
 
-  return html
-    .replace(STYLE_ATTR, (_match, dquoted?: string, squoted?: string) => {
-      const quote = dquoted !== undefined ? '"' : "'";
-      const cleaned = stripFontDeclarations(dquoted ?? squoted ?? '');
-      return cleaned === '' ? '' : ` style=${quote}${cleaned}${quote}`;
-    })
-    // Runs twice: the pattern consumes the space before each attribute, so a
-    // `<font face="…" size="…">` needs a second pass for its second attribute.
-    .replace(FONT_ELEMENT_ATTRS, '$1')
-    .replace(FONT_ELEMENT_ATTRS, '$1');
+/** Remove every pasted font, at every depth of the slice. */
+export function stripPastedFonts(slice: Slice): Slice {
+  return new Slice(stripFonts(slice.content), slice.openStart, slice.openEnd);
 }
 
 export const PasteFormatting = Extension.create({
   name: 'pasteFormatting',
 
   addProseMirrorPlugins() {
+    // Set while parsing an internal paste, and read once by the transform that
+    // follows it in the same paste. Reset on read: a plain-text paste never
+    // reaches transformPastedHTML at all, and must not inherit the answer from
+    // whatever was pasted before it.
+    let internal = false;
+
     return [
       new Plugin({
         key: new PluginKey('pasteFormatting'),
         props: {
-          transformPastedHTML: (html) => stripPastedFonts(html),
+          transformPastedHTML: (html) => {
+            internal = isInternalPaste(html);
+            return html;
+          },
+          transformPasted: (slice) => {
+            const wasInternal = internal;
+            internal = false;
+            return wasInternal ? slice : stripPastedFonts(slice);
+          },
         },
       }),
     ];

--- a/frontend/src/editor/extensions/PasteFormatting.ts
+++ b/frontend/src/editor/extensions/PasteFormatting.ts
@@ -1,0 +1,87 @@
+/**
+ * Keep a paste from another app from bringing that app's typography with it.
+ *
+ * Rich text on the clipboard carries an HTML flavour, and on iOS in particular
+ * that HTML tags every run with the source app's own inline font — usually a
+ * system alias such as `-apple-system` or `.SFUI-Regular`. TextStyle/FontFamily
+ * and FontSize read those declarations straight off the element, so the pasted
+ * text ended up in a font that matched neither the source (the alias resolves
+ * to whatever the web view falls back to) nor the screenplay around it.
+ *
+ * Stripping the font declarations before ProseMirror parses the HTML leaves the
+ * pasted text with no font of its own, so it inherits the destination element's
+ * — the screenplay's font and size. Emphasis is deliberately left alone: bold,
+ * italic, underline and colour are the writer's meaning, not the source app's
+ * house style.
+ *
+ * Text copied inside OpenDraft is exempt. ProseMirror stamps its own clipboard
+ * HTML with `data-pm-slice`, and a font set deliberately with the toolbar has
+ * to survive a copy and paste.
+ */
+import { Extension } from '@tiptap/core';
+import { Plugin, PluginKey } from '@tiptap/pm/state';
+
+/** ProseMirror's marker on clipboard HTML it wrote itself. */
+const INTERNAL_SLICE = /\sdata-pm-slice\s*=/i;
+
+/** `style="…"` / `style='…'`, capturing the declarations. */
+const STYLE_ATTR = /\sstyle\s*=\s*(?:"([^"]*)"|'([^']*)')/gi;
+
+/** The declarations that carry a font, including the `font:` shorthand. */
+const FONT_DECLARATION = /(?:^|;)\s*(?:-webkit-)?font(?:-family|-size)?\s*:[^;]*/gi;
+
+/** `face` and `size` on the deprecated `<font>` element. */
+const FONT_ELEMENT_ATTRS = /(<font\b[^>]*?)\s(?:face|size)\s*=\s*(?:"[^"]*"|'[^']*'|[^\s>]+)/gi;
+
+/**
+ * Rewrite `font: bold italic 12px Georgia` as the weight and style it also
+ * set, so dropping the shorthand does not quietly drop emphasis with it.
+ */
+function emphasisFromShorthand(declaration: string): string {
+  if (!/^\s*(?:;)?\s*(?:-webkit-)?font\s*:/i.test(declaration)) return '';
+  const kept: string[] = [];
+  if (/\b(bold|bolder|[5-9]00)\b/i.test(declaration)) kept.push('font-weight: bold');
+  if (/\b(italic|oblique)\b/i.test(declaration)) kept.push('font-style: italic');
+  return kept.length > 0 ? `;${kept.join(';')}` : '';
+}
+
+function stripFontDeclarations(declarations: string): string {
+  return declarations
+    .replace(FONT_DECLARATION, (match) => emphasisFromShorthand(match))
+    .replace(/^\s*;+/, '')
+    .trim();
+}
+
+/**
+ * Remove font-family and font-size from pasted HTML that came from outside
+ * the editor. Returns the HTML unchanged for an internal ProseMirror slice.
+ */
+export function stripPastedFonts(html: string): string {
+  if (INTERNAL_SLICE.test(html)) return html;
+
+  return html
+    .replace(STYLE_ATTR, (_match, dquoted?: string, squoted?: string) => {
+      const quote = dquoted !== undefined ? '"' : "'";
+      const cleaned = stripFontDeclarations(dquoted ?? squoted ?? '');
+      return cleaned === '' ? '' : ` style=${quote}${cleaned}${quote}`;
+    })
+    // Runs twice: the pattern consumes the space before each attribute, so a
+    // `<font face="…" size="…">` needs a second pass for its second attribute.
+    .replace(FONT_ELEMENT_ATTRS, '$1')
+    .replace(FONT_ELEMENT_ATTRS, '$1');
+}
+
+export const PasteFormatting = Extension.create({
+  name: 'pasteFormatting',
+
+  addProseMirrorPlugins() {
+    return [
+      new Plugin({
+        key: new PluginKey('pasteFormatting'),
+        props: {
+          transformPastedHTML: (html) => stripPastedFonts(html),
+        },
+      }),
+    ];
+  },
+});

--- a/frontend/src/editor/extensions/index.ts
+++ b/frontend/src/editor/extensions/index.ts
@@ -14,6 +14,7 @@ export { CastList } from './CastList';
 export { DualDialogue, DualDialogueColumn } from './DualDialogue';
 export { TitlePage } from './TitlePage';
 export { FontSize } from './FontSize';
+export { PasteFormatting, stripPastedFonts } from './PasteFormatting';
 export { ScriptNoteMark } from './ScriptNoteMark';
 export { TagMark } from './TagMark';
 export { FormatOverride } from './FormatOverride';

--- a/frontend/src/editor/pasteFormatting.test.ts
+++ b/frontend/src/editor/pasteFormatting.test.ts
@@ -1,0 +1,44 @@
+/**
+ * Pasting from another app used to bring that app's font with it — the report
+ * was an iPad paste landing in a font that matched neither the source nor the
+ * screenplay. These pin the HTML transform that drops it.
+ */
+import { describe, it, expect } from 'vitest';
+import { stripPastedFonts } from './extensions/PasteFormatting';
+
+describe('stripPastedFonts', () => {
+  it('drops font-family and font-size from external HTML', () => {
+    const html = '<span style="font-family: -apple-system; font-size: 17px;">Hello</span>';
+    expect(stripPastedFonts(html)).toBe('<span>Hello</span>');
+  });
+
+  it('keeps the declarations that carry meaning', () => {
+    const html = '<span style="font-family: Helvetica; font-weight: bold; color: rgb(255, 0, 0)">Hi</span>';
+    expect(stripPastedFonts(html)).toBe('<span style="font-weight: bold; color: rgb(255, 0, 0)">Hi</span>');
+  });
+
+  it('keeps the emphasis inside a font shorthand it removes', () => {
+    const html = "<p style=\"font: bold italic 12.0px '.SFUI-Regular'\">Hi</p>";
+    expect(stripPastedFonts(html)).toBe('<p style="font-weight: bold;font-style: italic">Hi</p>');
+  });
+
+  it('drops face and size from a legacy font element', () => {
+    const html = '<font face="Arial" size="4" color="#333">Hi</font>';
+    expect(stripPastedFonts(html)).toBe('<font color="#333">Hi</font>');
+  });
+
+  it('leaves single-quoted style attributes valid', () => {
+    const html = "<span style='font-size: 17px; color: red'>Hi</span>";
+    expect(stripPastedFonts(html)).toBe("<span style='color: red'>Hi</span>");
+  });
+
+  it('leaves a copy made inside the editor untouched', () => {
+    const html = '<div data-pm-slice="1 1 []"><p style="font-family: Courier Prime">Hi</p></div>';
+    expect(stripPastedFonts(html)).toBe(html);
+  });
+
+  it('leaves HTML with no styling alone', () => {
+    const html = '<p>Plain <strong>and bold</strong></p>';
+    expect(stripPastedFonts(html)).toBe(html);
+  });
+});

--- a/frontend/src/editor/pasteFormatting.test.ts
+++ b/frontend/src/editor/pasteFormatting.test.ts
@@ -1,44 +1,127 @@
 /**
  * Pasting from another app used to bring that app's font with it — the report
  * was an iPad paste landing in a font that matched neither the source nor the
- * screenplay. These pin the HTML transform that drops it.
+ * screenplay. These pin the transform that drops it.
+ *
+ * The schema here is deliberately local and minimal: the font attributes live
+ * on `textStyle`, so a document node, some text and the three mark extensions
+ * that write those attributes are the whole surface under test.
  */
 import { describe, it, expect } from 'vitest';
-import { stripPastedFonts } from './extensions/PasteFormatting';
+import { getSchema } from '@tiptap/core';
+import Document from '@tiptap/extension-document';
+import Text from '@tiptap/extension-text';
+import Bold from '@tiptap/extension-bold';
+import TextStyle from '@tiptap/extension-text-style';
+import FontFamily from '@tiptap/extension-font-family';
+import Color from '@tiptap/extension-color';
+import { Slice } from '@tiptap/pm/model';
+import type { JSONContent } from '@tiptap/core';
+
+import { Action } from './extensions/Action';
+import { FontSize } from './extensions/FontSize';
+import { stripPastedFonts, isInternalPaste } from './extensions/PasteFormatting';
+
+const schema = getSchema([
+  Document.extend({ content: 'block+' }),
+  Text, Bold, TextStyle, FontFamily, FontSize, Color, Action,
+]);
+
+/** A one-block slice, as a paste of whole blocks arrives. */
+function slice(...content: JSONContent[]): Slice {
+  return new Slice(schema.nodeFromJSON({ type: 'doc', content }).content, 0, 0);
+}
+
+/** [text, marks-as-JSON] for every text run in the slice. */
+function runs(result: Slice): [string, unknown[]][] {
+  const out: [string, unknown[]][] = [];
+  result.content.descendants((node) => {
+    if (node.isText) out.push([node.text ?? '', node.marks.map((m) => m.toJSON())]);
+  });
+  return out;
+}
+
+const textStyle = (attrs: Record<string, string>) => ({ type: 'textStyle', attrs });
 
 describe('stripPastedFonts', () => {
-  it('drops font-family and font-size from external HTML', () => {
-    const html = '<span style="font-family: -apple-system; font-size: 17px;">Hello</span>';
-    expect(stripPastedFonts(html)).toBe('<span>Hello</span>');
+  it('drops the font a source app tagged its text with', () => {
+    const result = stripPastedFonts(slice({
+      type: 'action',
+      content: [{
+        type: 'text',
+        text: 'Anna makes coffee.',
+        marks: [textStyle({ fontFamily: '-apple-system', fontSize: '17px' })],
+      }],
+    }));
+
+    expect(runs(result)).toEqual([['Anna makes coffee.', []]]);
   });
 
-  it('keeps the declarations that carry meaning', () => {
-    const html = '<span style="font-family: Helvetica; font-weight: bold; color: rgb(255, 0, 0)">Hi</span>';
-    expect(stripPastedFonts(html)).toBe('<span style="font-weight: bold; color: rgb(255, 0, 0)">Hi</span>');
+  it('keeps the marks that carry meaning', () => {
+    const result = stripPastedFonts(slice({
+      type: 'action',
+      content: [{
+        type: 'text',
+        text: 'Loud.',
+        marks: [{ type: 'bold' }, textStyle({ fontFamily: 'Helvetica', color: 'rgb(255, 0, 0)' })],
+      }],
+    }));
+
+    // Marks come back in schema order, textStyle before bold.
+    expect(runs(result)).toEqual([
+      ['Loud.', [{ type: 'textStyle', attrs: { color: 'rgb(255, 0, 0)', fontFamily: null, fontSize: null } }, { type: 'bold' }]],
+    ]);
   });
 
-  it('keeps the emphasis inside a font shorthand it removes', () => {
-    const html = "<p style=\"font: bold italic 12.0px '.SFUI-Regular'\">Hi</p>";
-    expect(stripPastedFonts(html)).toBe('<p style="font-weight: bold;font-style: italic">Hi</p>');
+  it('strips every run, at every depth', () => {
+    const result = stripPastedFonts(slice(
+      { type: 'action', content: [{ type: 'text', text: 'One', marks: [textStyle({ fontSize: '17px' })] }] },
+      { type: 'action', content: [
+        { type: 'text', text: 'Two', marks: [textStyle({ fontFamily: 'Georgia' })] },
+        { type: 'text', text: ' three' },
+      ] },
+    ));
+
+    // 'Two' and ' three' come back as one run: stripping the font left them
+    // with identical marks, and ProseMirror joins adjacent text nodes that
+    // carry the same marks. That is the point — the paste stops being a patch-
+    // work of runs and becomes ordinary screenplay text.
+    expect(runs(result)).toEqual([['One', []], ['Two three', []]]);
   });
 
-  it('drops face and size from a legacy font element', () => {
-    const html = '<font face="Arial" size="4" color="#333">Hi</font>';
-    expect(stripPastedFonts(html)).toBe('<font color="#333">Hi</font>');
+  it('leaves text with no font of its own untouched', () => {
+    const original = slice({ type: 'action', content: [{ type: 'text', text: 'Plain' }] });
+
+    expect(stripPastedFonts(original).eq(original)).toBe(true);
   });
 
-  it('leaves single-quoted style attributes valid', () => {
-    const html = "<span style='font-size: 17px; color: red'>Hi</span>";
-    expect(stripPastedFonts(html)).toBe("<span style='color: red'>Hi</span>");
+  it('keeps the slice open depths, so a paste still merges into its block', () => {
+    const open = new Slice(
+      schema.nodeFromJSON({
+        type: 'doc',
+        content: [{ type: 'action', content: [{ type: 'text', text: 'Anna', marks: [textStyle({ fontSize: '17px' })] }] }],
+      }).content,
+      1,
+      1,
+    );
+    const result = stripPastedFonts(open);
+
+    expect(result.openStart).toBe(1);
+    expect(result.openEnd).toBe(1);
+    expect(runs(result)).toEqual([['Anna', []]]);
+  });
+});
+
+describe('isInternalPaste', () => {
+  it('recognises ProseMirror’s own clipboard HTML', () => {
+    expect(isInternalPaste('<div data-pm-slice="1 1 []"><p>Anna</p></div>')).toBe(true);
   });
 
-  it('leaves a copy made inside the editor untouched', () => {
-    const html = '<div data-pm-slice="1 1 []"><p style="font-family: Courier Prime">Hi</p></div>';
-    expect(stripPastedFonts(html)).toBe(html);
+  it('does not take prose that mentions the attribute for markup', () => {
+    expect(isInternalPaste('<p>ProseMirror writes data-pm-slice="1 1 []" on a copy.</p>')).toBe(false);
   });
 
-  it('leaves HTML with no styling alone', () => {
-    const html = '<p>Plain <strong>and bold</strong></p>';
-    expect(stripPastedFonts(html)).toBe(html);
+  it('treats HTML from another app as external', () => {
+    expect(isInternalPaste('<span style="font-family: -apple-system">Anna</span>')).toBe(false);
   });
 });

--- a/frontend/src/utils/fountainParser.test.ts
+++ b/frontend/src/utils/fountainParser.test.ts
@@ -157,3 +157,71 @@ describe('parseFountain — regression', () => {
     expect(parse('')).toEqual([{ type: 'action', content: [] }]);
   });
 });
+
+/**
+ * "Paste as Fountain" feeds this parser whatever the clipboard hands over, and
+ * a clipboard is not a file: an iPad paste can arrive with lone carriage
+ * returns or Unicode separators instead of newlines, and rich text flattened
+ * to plain text arrives single-spaced. Every one of those used to come out as
+ * Action — nothing split, or nothing had the blank line a cue is recognised by.
+ */
+describe('parseFountain — clipboard text', () => {
+  const SCENE = [
+    'INT. KITCHEN - DAY',
+    '',
+    'Anna makes coffee.',
+    '',
+    'ANNA',
+    '(tired)',
+    'Morning.',
+    '',
+    'CUT TO:',
+  ].join('\n');
+
+  const EXPECTED = [
+    'sceneHeading', 'action', 'character', 'parenthetical', 'dialogue', 'transition',
+  ];
+
+  it.each([
+    ['carriage returns', SCENE.replace(/\n/g, '\r')],
+    ['CRLF', SCENE.replace(/\n/g, '\r\n')],
+    ['Unicode line separators', SCENE.replace(/\n/g, '\u2028')],
+    ['Unicode paragraph separators', SCENE.replace(/\n/g, '\u2029')],
+    ['a byte order mark', `\uFEFF${SCENE}`],
+  ])('reads a scene delimited by %s', (_label, text) => {
+    expect(parse(text).map((n) => n.type)).toEqual(EXPECTED);
+  });
+
+  it('reads cues and dialogue out of single-spaced text', () => {
+    const nodes = parse(SCENE.replace(/\n\n/g, '\n'));
+
+    expect(nodes.map((n) => n.type)).toEqual(EXPECTED);
+    expect(nodes.map(textOf)).toEqual([
+      'INT. KITCHEN - DAY', 'Anna makes coffee.', 'ANNA', '(tired)', 'Morning.', 'CUT TO:',
+    ]);
+  });
+
+  it('ends a single-spaced dialogue block at the next element', () => {
+    const nodes = parse(['ANNA', 'Morning.', 'INT. HALL - DAY', 'Ben waits.'].join('\n'));
+
+    expect(nodes.map((n) => n.type)).toEqual(['character', 'dialogue', 'sceneHeading', 'action']);
+  });
+
+  it('keeps consecutive dialogue lines in a single-spaced block', () => {
+    const nodes = parse(['ANNA', 'Morning.', 'Sleep well?', 'BEN', 'Not really.'].join('\n'));
+
+    expect(nodes.map((n) => n.type)).toEqual(['character', 'dialogue', 'dialogue', 'character', 'dialogue']);
+  });
+
+  it('leaves an all-caps sentence as Action in single-spaced text', () => {
+    const nodes = parse(['Ben waits.', 'THE DOOR SLAMS SHUT.', 'Anna is gone.'].join('\n'));
+
+    expect(nodes.map((n) => n.type)).toEqual(['action', 'action', 'action']);
+  });
+
+  it('does not read a cue by shape once the text has blank lines', () => {
+    const nodes = parse(['Ben waits.', '', 'Anna arrives.', 'ANNA IS HERE', 'She waves.'].join('\n'));
+
+    expect(nodes.map((n) => n.type)).toEqual(['action', 'action', 'action', 'action']);
+  });
+});

--- a/frontend/src/utils/fountainParser.test.ts
+++ b/frontend/src/utils/fountainParser.test.ts
@@ -219,6 +219,28 @@ describe('parseFountain — clipboard text', () => {
     expect(nodes.map((n) => n.type)).toEqual(['action', 'action', 'action']);
   });
 
+  it.each([
+    ['a trailing newline', `${'INT. KITCHEN - DAY\nAnna makes coffee.\nANNA\n(tired)\nMorning.\nCUT TO:'}\n`],
+    ['a leading newline', `\n${'INT. KITCHEN - DAY\nAnna makes coffee.\nANNA\n(tired)\nMorning.\nCUT TO:'}`],
+  ])('still reads single-spaced text with %s', (_label, text) => {
+    // `split` leaves an empty element for the newline clipboard text almost
+    // always ends with. Counted as a blank line, it turned the single-spaced
+    // rule off for the most ordinary paste there is.
+    expect(parse(text).map((n) => n.type)).toEqual(EXPECTED);
+  });
+
+  it('leaves FADE IN: as Action at the top of single-spaced text', () => {
+    const nodes = parse(['FADE IN:', 'INT. KITCHEN - DAY', 'Anna makes coffee.', 'ANNA', 'Morning.'].join('\n'));
+
+    expect(nodes.map((n) => n.type)).toEqual(['action', 'sceneHeading', 'action', 'character', 'dialogue']);
+  });
+
+  it('does not make a cue of an all-caps line with a scene heading under it', () => {
+    const nodes = parse(['ANNA', 'INT. HALL - DAY', 'Ben waits.'].join('\n'));
+
+    expect(nodes.map((n) => n.type)).toEqual(['action', 'sceneHeading', 'action']);
+  });
+
   it('does not read a cue by shape once the text has blank lines', () => {
     const nodes = parse(['Ben waits.', '', 'Anna arrives.', 'ANNA IS HERE', 'She waves.'].join('\n'));
 

--- a/frontend/src/utils/fountainParser.ts
+++ b/frontend/src/utils/fountainParser.ts
@@ -107,6 +107,30 @@ function splitLines(text: string): string[] {
   return text.replace(/^\uFEFF/, '').replace(LINE_SEPARATORS, '\n').split('\n');
 }
 
+/**
+ * Is this text single-spaced — no blank line anywhere between its lines?
+ *
+ * Fountain marks a character cue with the blank line before it. Text that has
+ * no blank lines anywhere never lost them in transit — it never had them: rich
+ * text converted to plain text, and a script copied out of an app that lays
+ * cues out by indentation rather than by spacing, both arrive single-spaced.
+ * Read cues by their shape there, or every cue, parenthetical and line of
+ * dialogue in the paste comes through as Action.
+ *
+ * Blank lines at the ends do not count. `split` leaves an empty last element
+ * for the trailing newline that clipboard text almost always carries, and
+ * counting that as a blank line turned this off for the most ordinary paste
+ * there is — the whole point of the rule, defeated by one invisible character.
+ */
+function isSingleSpaced(lines: string[]): boolean {
+  let first = 0;
+  let last = lines.length - 1;
+  while (first <= last && lines[first].trim() === '') first++;
+  while (last >= first && lines[last].trim() === '') last--;
+  if (last - first < 1) return false;
+  return !lines.slice(first, last + 1).some((line) => line.trim() === '');
+}
+
 /** Scene heading by its opening: `INT.`, `EXT.`, `EST.`, `INT./EXT.`, `I/E.` */
 function isSceneHeadingLine(trimmed: string): boolean {
   return /^(INT\.|EXT\.|EST\.|INT\.\/EXT\.|I\/E\.)/.test(trimmed.toUpperCase());
@@ -119,13 +143,7 @@ function isTransitionLine(trimmed: string): boolean {
 
 export function parseFountain(text: string): TipTapNode {
   const lines = splitLines(text);
-  // Fountain marks a character cue with the blank line before it. Text that
-  // has no blank lines anywhere never lost them in transit — it never had
-  // them: rich text converted to plain text, and a script copied out of an app
-  // that lays cues out by indentation rather than by spacing, both arrive
-  // single-spaced. Read cues by their shape there, or every cue, parenthetical
-  // and line of dialogue in the paste comes through as Action.
-  const singleSpaced = lines.length > 1 && !lines.some((line) => line.trim() === '');
+  const singleSpaced = isSingleSpaced(lines);
   const nodes: TipTapNode[] = [];
   let i = 0;
 
@@ -242,8 +260,14 @@ export function parseFountain(text: string): TipTapNode {
     // Character: all uppercase, preceded by an empty line, and followed by the
     // dialogue it introduces.
     if (isCharacterLine(trimmed.replace(/\s*\^$/, ''))
-      && (isPrecededByEmptyLine(lines, i) || (singleSpaced && looksLikeCue(trimmed)))
-      && isFollowedByText(lines, i)) {
+      // Single-spaced text has no blank line to go on, so shape is the whole
+      // test — and it has to replace the blank-line rule rather than fall back
+      // to it, because `isPrecededByEmptyLine` is true at the first line. That
+      // exempted the opening line from the shape test, and most pasted scripts
+      // open with `FADE IN:` — which became a cue with the scene heading under
+      // it as its dialogue.
+      && (singleSpaced ? looksLikeCue(trimmed) : isPrecededByEmptyLine(lines, i))
+      && isFollowedByDialogue(lines, i, singleSpaced)) {
       let charName = trimmed;
       const isDual = charName.endsWith('^');
       if (isDual) charName = charName.replace(/\s*\^$/, '').trim();
@@ -451,6 +475,22 @@ function looksLikeCue(line: string): boolean {
 }
 
 /**
+ * Does this line say outright that it is not dialogue?
+ *
+ * A scene heading, a transition or a forced element is unambiguous wherever it
+ * lands: whatever came before it, it ends the block.
+ */
+function opensHardElement(trimmed: string): boolean {
+  if (trimmed === '') return true;
+  // Forced action, character, transition/centred text, and page break. `~`
+  // (lyrics) is deliberately absent: lyrics belong inside a dialogue block.
+  if (/^[!@>=]/.test(trimmed)) return true;
+  // Forced scene heading — `.INT` and not an ellipsis.
+  if (/^\.[^.]/.test(trimmed)) return true;
+  return isSceneHeadingLine(trimmed) || isTransitionLine(trimmed);
+}
+
+/**
  * Does this line open an element of its own?
  *
  * The end of a dialogue block is normally the next blank line. Single-spaced
@@ -460,13 +500,7 @@ function looksLikeCue(line: string): boolean {
  */
 function opensNewElement(lines: string[], index: number): boolean {
   const trimmed = (lines[index] ?? '').trim();
-  if (trimmed === '') return true;
-  // Forced action, character, transition/centred text, and page break. `~`
-  // (lyrics) is deliberately absent: lyrics belong inside a dialogue block.
-  if (/^[!@>=]/.test(trimmed)) return true;
-  // Forced scene heading — `.INT` and not an ellipsis.
-  if (/^\.[^.]/.test(trimmed)) return true;
-  if (isSceneHeadingLine(trimmed) || isTransitionLine(trimmed)) return true;
+  if (opensHardElement(trimmed)) return true;
   return isCharacterLine(trimmed.replace(/\s*\^$/, ''))
     && looksLikeCue(trimmed)
     && isFollowedByText(lines, index);
@@ -489,6 +523,20 @@ function isPrecededByEmptyLine(lines: string[], index: number): boolean {
 function isFollowedByText(lines: string[], index: number): boolean {
   const next = lines[index + 1];
   return next !== undefined && next.trim() !== '';
+}
+
+/**
+ * The cue's other half, for single-spaced text: is the line under it something
+ * that can actually be its dialogue?
+ *
+ * A blank line answers this in ordinary Fountain. Single-spaced there is none,
+ * so a scene heading under an all-caps line has to be what rules the line out
+ * — otherwise a cue is emitted with a scene heading as its dialogue, or worse,
+ * with nothing under it at all.
+ */
+function isFollowedByDialogue(lines: string[], index: number, singleSpaced: boolean): boolean {
+  if (!isFollowedByText(lines, index)) return false;
+  return !singleSpaced || !opensHardElement((lines[index + 1] ?? '').trim());
 }
 
 const DIALOGUE_TYPES = new Set(['character', 'dialogue', 'parenthetical']);

--- a/frontend/src/utils/fountainParser.ts
+++ b/frontend/src/utils/fountainParser.ts
@@ -87,8 +87,45 @@ function parseTitlePage(lines: string[]): { next: number; nodes: TipTapNode[] } 
   return { next: i, nodes: blocks };
 }
 
+/**
+ * Every separator a line of text can arrive with, other than the plain `\n`
+ * this parser works in.
+ *
+ * Splitting on `\n` alone is only safe for text that was written to a file by
+ * something that agrees on newlines. Text off a clipboard is not: pasting from
+ * an iPad (and from older editors on any platform) can arrive with lone
+ * carriage returns, and rich text converted to plain text carries Unicode's
+ * own line (U+2028) and paragraph (U+2029) separators. None of those split,
+ * so the whole paste stayed one line — and one line of a screenplay, whatever
+ * it says, parses as a single Action block. That is what "Paste as Fountain
+ * inserts everything as Action" looked like from the outside.
+ */
+const LINE_SEPARATORS = /\r\n?|\u2028|\u2029|\u0085/g;
+
+/** Split text into lines, whichever separator convention it arrived with. */
+function splitLines(text: string): string[] {
+  return text.replace(/^\uFEFF/, '').replace(LINE_SEPARATORS, '\n').split('\n');
+}
+
+/** Scene heading by its opening: `INT.`, `EXT.`, `EST.`, `INT./EXT.`, `I/E.` */
+function isSceneHeadingLine(trimmed: string): boolean {
+  return /^(INT\.|EXT\.|EST\.|INT\.\/EXT\.|I\/E\.)/.test(trimmed.toUpperCase());
+}
+
+/** Transition by its shape: all caps, ending in `TO:`. */
+function isTransitionLine(trimmed: string): boolean {
+  return /^[A-Z\s]+TO:$/.test(trimmed);
+}
+
 export function parseFountain(text: string): TipTapNode {
-  const lines = text.split('\n');
+  const lines = splitLines(text);
+  // Fountain marks a character cue with the blank line before it. Text that
+  // has no blank lines anywhere never lost them in transit — it never had
+  // them: rich text converted to plain text, and a script copied out of an app
+  // that lays cues out by indentation rather than by spacing, both arrive
+  // single-spaced. Read cues by their shape there, or every cue, parenthetical
+  // and line of dialogue in the paste comes through as Action.
+  const singleSpaced = lines.length > 1 && !lines.some((line) => line.trim() === '');
   const nodes: TipTapNode[] = [];
   let i = 0;
 
@@ -159,7 +196,7 @@ export function parseFountain(text: string): TipTapNode {
     }
 
     // Scene heading: starts with INT., EXT., EST., INT/EXT., I/E.
-    if (/^(INT\.|EXT\.|EST\.|INT\.\/EXT\.|I\/E\.)/.test(trimmed.toUpperCase())) {
+    if (isSceneHeadingLine(trimmed)) {
       push(makeSceneHeading(trimmed));
       i++;
       continue;
@@ -182,7 +219,7 @@ export function parseFountain(text: string): TipTapNode {
     }
 
     // Transition: all caps ending with TO:
-    if (/^[A-Z\s]+TO:$/.test(trimmed)) {
+    if (isTransitionLine(trimmed)) {
       push(makeNode('transition', trimmed));
       i++;
       continue;
@@ -198,14 +235,14 @@ export function parseFountain(text: string): TipTapNode {
       if (isDual) charNode.attrs = { ...charNode.attrs, dualDialogue: true };
       push(charNode);
       i++;
-      i = collectDialogueBlock(lines, i, push);
+      i = collectDialogueBlock(lines, i, push, singleSpaced);
       continue;
     }
 
     // Character: all uppercase, preceded by an empty line, and followed by the
     // dialogue it introduces.
     if (isCharacterLine(trimmed.replace(/\s*\^$/, ''))
-      && isPrecededByEmptyLine(lines, i)
+      && (isPrecededByEmptyLine(lines, i) || (singleSpaced && looksLikeCue(trimmed)))
       && isFollowedByText(lines, i)) {
       let charName = trimmed;
       const isDual = charName.endsWith('^');
@@ -214,7 +251,7 @@ export function parseFountain(text: string): TipTapNode {
       if (isDual) charNode.attrs = { ...charNode.attrs, dualDialogue: true };
       push(charNode);
       i++;
-      i = collectDialogueBlock(lines, i, push);
+      i = collectDialogueBlock(lines, i, push, singleSpaced);
       continue;
     }
 
@@ -396,6 +433,45 @@ function isCharacterLine(line: string): boolean {
   return cleaned.length > 0 && cleaned === cleaned.toUpperCase() && /[A-Z]/.test(cleaned);
 }
 
+/**
+ * Does an all-caps line look like a character cue rather than a line of
+ * shouted Action?
+ *
+ * Only consulted for single-spaced text, where the blank line the spec uses to
+ * tell the two apart is not available. A cue is a name: short, and not a
+ * sentence, so the length cap and the trailing punctuation are what separate
+ * `SAM` from `THE DOOR SLAMS SHUT.`
+ */
+const CUE_MAX_LENGTH = 45;
+
+function looksLikeCue(line: string): boolean {
+  const cleaned = line.replace(/\(.*\)/, '').replace(/\s*\^$/, '').trim();
+  if (cleaned.length === 0 || cleaned.length > CUE_MAX_LENGTH) return false;
+  return !/[.,!?;:—-]$/.test(cleaned);
+}
+
+/**
+ * Does this line open an element of its own?
+ *
+ * The end of a dialogue block is normally the next blank line. Single-spaced
+ * text has none, so the block has to end where the next element begins —
+ * without this the first cue in a paste swallowed everything after it as
+ * dialogue.
+ */
+function opensNewElement(lines: string[], index: number): boolean {
+  const trimmed = (lines[index] ?? '').trim();
+  if (trimmed === '') return true;
+  // Forced action, character, transition/centred text, and page break. `~`
+  // (lyrics) is deliberately absent: lyrics belong inside a dialogue block.
+  if (/^[!@>=]/.test(trimmed)) return true;
+  // Forced scene heading — `.INT` and not an ellipsis.
+  if (/^\.[^.]/.test(trimmed)) return true;
+  if (isSceneHeadingLine(trimmed) || isTransitionLine(trimmed)) return true;
+  return isCharacterLine(trimmed.replace(/\s*\^$/, ''))
+    && looksLikeCue(trimmed)
+    && isFollowedByText(lines, index);
+}
+
 function isPrecededByEmptyLine(lines: string[], index: number): boolean {
   if (index === 0) return true;
   return lines[index - 1].trim() === '';
@@ -479,12 +555,21 @@ function collectDialogueBlock(
   lines: string[],
   i: number,
   push: (node: TipTapNode) => void,
+  singleSpaced = false,
 ): number {
+  const first = i;
   while (i < lines.length) {
     const line = lines[i];
     const trimmed = line.trim();
 
     if (trimmed === '') {
+      break;
+    }
+
+    // The line straight after a cue is always its dialogue — a cue with
+    // nothing under it was never treated as a cue. Past that, single-spaced
+    // text ends the block at the next element rather than at a blank line.
+    if (singleSpaced && i > first && opensNewElement(lines, i)) {
       break;
     }
 


### PR DESCRIPTION
## What does this PR do?

Fixes #82 and fixes #81 — the two open iPad paste reports.

**#82 — "Paste as Fountain" inserted everything as Action.** Two causes in `frontend/src/utils/fountainParser.ts`:

1. The parser split its input on `\n` alone. That is safe for a file written by something that agrees on newlines, and wrong for a clipboard: a paste can arrive with lone carriage returns, or with Unicode's line (U+2028) and paragraph (U+2029) separators from rich text flattened to plain text. None of those split, so the whole paste stayed one line — and one line of a screenplay parses as a single Action block. Every separator is now normalised first, and a leading byte order mark is dropped.
2. The same paste can arrive single-spaced, because flattening rich text to plain text loses the blank lines. Fountain recognises a character cue *by the blank line before it*, so a single-spaced script came through with its cues, parentheticals and dialogue all as Action. When the text has no blank lines anywhere, cues are read by their shape instead — short, all caps, not a sentence, and with something under it that can actually be its dialogue — and the dialogue block ends at the next element rather than at a blank line that never comes. Text that does have blank lines parses exactly as before.

Blank lines at the *ends* of the text do not count towards that judgement. `split` leaves an empty last element for the trailing newline clipboard text almost always carries, and counting it turned the rule off for the most ordinary paste there is.

**#81 — normal paste used a font matching neither source nor screenplay.** Rich text on the clipboard carries an HTML flavour, and on iOS that HTML tags every run with the source app's own inline font — usually a system alias such as `-apple-system` or `.SFUI-Regular`, which resolves to whatever the web view falls back to. `TextStyle`/`FontFamily` and `FontSize` read those declarations straight off the element.

A new `PasteFormatting` extension drops the font from the parsed slice in `transformPasted`, rather than editing the clipboard HTML on the way in. Once ProseMirror has parsed the clipboard there is nothing to guess at — a font is a `textStyle` mark with a `fontFamily` or `fontSize` attribute — so pasted text is left inheriting the destination element's font and size, which is the "adopt the destination screenplay's font" option the issue asked for. Emphasis and colour ride on their own marks and are untouched, and text copied inside OpenDraft is exempt via `data-pm-slice`, so a font set deliberately with the toolbar still survives a copy and paste.

One caveat: I have no iPad to hand, so this fixes the failure modes the code demonstrably has for clipboard-shaped input rather than confirming the exact bytes iOS delivers. If #82 persists, the next thing to capture is the raw `navigator.clipboard.readText()` string on the device.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring (no functional change)
- [ ] Documentation
- [ ] Other (describe below)

## How was this tested?

22 new unit tests, plus the existing suite:

- `frontend/src/utils/fountainParser.test.ts` — a scene delimited by CR, CRLF, U+2028, U+2029 and with a leading BOM all parse to the same elements; the same scene single-spaced, and single-spaced with a leading or trailing newline; a single-spaced dialogue block ends at the next element and keeps consecutive dialogue lines; `FADE IN:` at the top stays Action; an all-caps line with a scene heading under it is not a cue; an all-caps sentence stays Action; and cue-by-shape does not kick in once the text has blank lines.
- `frontend/src/editor/pasteFormatting.test.ts` — against a real schema, asserting on marks: the source app's font is dropped at every depth, bold and colour survive, a slice with no font of its own is returned unchanged, open depths are preserved so a paste still merges into its block, and `isInternalPaste` tells ProseMirror's own clipboard HTML from prose that merely quotes the attribute.

`npx vitest run` — 529 passed (38 files). `npx tsc -b` clean. `npm run build` succeeds. `npx eslint` on the touched files reports no new problems (the one remaining `fountainParser.ts` error predates this branch).

## Screenshots (if applicable)

n/a — no UI changes.

## Checklist

- [x] I've read the [Contributing Guide](docs/CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I've tested my changes locally
- [ ] I've updated documentation if needed — no user-facing behaviour to document beyond the fixes themselves