### PR TITLE
Read Fountain's non-printing structure instead of printing it

### DIFF
--- a/frontend/src/components/ElementPicker.tsx
+++ b/frontend/src/components/ElementPicker.tsx
@@ -4,6 +4,10 @@ import { ELEMENT_DESCRIPTIONS } from '../stores/formattingTypes';
 import { useFormattingTemplateStore } from '../stores/formattingTemplateStore';
 
 // Context-aware element ordering: most likely choices first per current type
+// The two non-printing elements sit at the end of every list: they are
+// structure, not script, so they should never be the first thing offered.
+const OUTLINE_TYPES: ElementType[] = ['section', 'note'];
+
 const ELEMENT_ORDER: Record<string, ElementType[]> = {
   sceneHeading: ['action', 'character', 'general', 'transition', 'shot', 'sceneHeading', 'dialogue', 'parenthetical', 'newAct', 'endOfAct', 'lyrics', 'showEpisode', 'castList'],
   action:       ['action', 'character', 'dialogue', 'general', 'sceneHeading', 'transition', 'shot', 'parenthetical', 'newAct', 'endOfAct', 'lyrics', 'showEpisode', 'castList'],
@@ -18,11 +22,17 @@ const ELEMENT_ORDER: Record<string, ElementType[]> = {
   lyrics:       ['lyrics', 'dialogue', 'action', 'character', 'general', 'sceneHeading', 'parenthetical', 'transition', 'shot', 'newAct', 'endOfAct', 'showEpisode', 'castList'],
   showEpisode:  ['action', 'sceneHeading', 'showEpisode', 'general', 'character', 'dialogue', 'parenthetical', 'transition', 'shot', 'newAct', 'endOfAct', 'lyrics', 'castList'],
   castList:     ['castList', 'action', 'character', 'general', 'sceneHeading', 'dialogue', 'parenthetical', 'transition', 'shot', 'newAct', 'endOfAct', 'lyrics', 'showEpisode'],
+  section:      ['action', 'sceneHeading', 'section', 'general', 'character', 'dialogue', 'parenthetical', 'transition', 'shot', 'newAct', 'endOfAct', 'lyrics', 'showEpisode', 'castList'],
+  note:         ['action', 'note', 'sceneHeading', 'general', 'character', 'dialogue', 'parenthetical', 'transition', 'shot', 'newAct', 'endOfAct', 'lyrics', 'showEpisode', 'castList'],
 };
+for (const [type, order] of Object.entries(ELEMENT_ORDER)) {
+  ELEMENT_ORDER[type] = [...order, ...OUTLINE_TYPES.filter((t) => !order.includes(t))];
+}
 
 const DEFAULT_ORDER: ElementType[] = [
   'action', 'character', 'dialogue', 'general', 'sceneHeading', 'parenthetical',
   'transition', 'shot', 'newAct', 'endOfAct', 'lyrics', 'showEpisode', 'castList',
+  ...OUTLINE_TYPES,
 ];
 
 interface ElementPickerProps {

--- a/frontend/src/components/MobileAccessoryBar.tsx
+++ b/frontend/src/components/MobileAccessoryBar.tsx
@@ -6,10 +6,15 @@ import { useEditorStore } from '../stores/editorStore';
 import { singleLine } from '../utils/nodeText';
 
 // Element types for the picker sheet
+// Fountain's non-printing structural elements. Last in every list — they are
+// outline, not script, so they must never crowd out the element a writer is
+// reaching for mid-scene.
+const OUTLINE_TYPES: ElementType[] = ['section', 'note'];
+
 const ELEMENT_TYPES: ElementType[] = [
   'sceneHeading', 'action', 'character', 'dialogue', 'parenthetical',
   'transition', 'general', 'shot', 'newAct', 'endOfAct', 'lyrics',
-  'showEpisode', 'castList',
+  'showEpisode', 'castList', ...OUTLINE_TYPES,
 ];
 
 // Context-aware ordering: most likely choices first
@@ -27,7 +32,12 @@ const ELEMENT_ORDER: Record<string, ElementType[]> = {
   lyrics:       ['lyrics', 'dialogue', 'action', 'character', 'general', 'sceneHeading', 'parenthetical', 'transition', 'shot', 'newAct', 'endOfAct', 'showEpisode', 'castList'],
   showEpisode:  ['action', 'sceneHeading', 'showEpisode', 'general', 'character', 'dialogue', 'parenthetical', 'transition', 'shot', 'newAct', 'endOfAct', 'lyrics', 'castList'],
   castList:     ['castList', 'action', 'character', 'general', 'sceneHeading', 'dialogue', 'parenthetical', 'transition', 'shot', 'newAct', 'endOfAct', 'lyrics', 'showEpisode'],
+  section:      ['action', 'sceneHeading', 'section', 'general', 'character', 'dialogue', 'parenthetical', 'transition', 'shot', 'newAct', 'endOfAct', 'lyrics', 'showEpisode', 'castList'],
+  note:         ['action', 'note', 'sceneHeading', 'general', 'character', 'dialogue', 'parenthetical', 'transition', 'shot', 'newAct', 'endOfAct', 'lyrics', 'showEpisode', 'castList'],
 };
+for (const [type, order] of Object.entries(ELEMENT_ORDER)) {
+  ELEMENT_ORDER[type] = [...order, ...OUTLINE_TYPES.filter((t) => !order.includes(t))];
+}
 
 interface MobileAccessoryBarProps {
   editor: Editor;

--- a/frontend/src/components/SceneNavigator.tsx
+++ b/frontend/src/components/SceneNavigator.tsx
@@ -6,7 +6,7 @@ import { useEditorStore } from '../stores/editorStore';
 import { computeSceneLengths, computePageBlocks, activeTemplateHints, type PageContentInfo } from '../editor/pagination';
 import { getSpaceBefore } from '../utils/elementSpacing';
 import { computeSceneTiming, formatSceneDuration, getTimingColor } from '../utils/scriptTiming';
-import { computeScriptStructure, sceneActLabel, type ScriptStructure } from '../utils/scriptStructure';
+import { computeScriptStructure, sceneActLabel, type ScriptStructure, type StructureSection } from '../utils/scriptStructure';
 import SynopsisModal from './SynopsisModal';
 import { showToast } from './Toast';
 import { blockContentRange, characterKey, singleLine } from '../utils/nodeText';
@@ -189,6 +189,76 @@ const FD_INDENTS: Record<string, [number, number]> = {
 
 const LINE_HEIGHT_PX = 12 * (96 / 72); // 16px — matches pagination LINE_HEIGHT_PT
 
+// ── Section outline ─────────────────────────────────────────────────────
+
+interface SectionOutlineProps {
+  sections: StructureSection[];
+  onGoToSection: (sectionIndex: number) => void;
+  onGoToScene: (sceneIndex: number) => void;
+  query: string;
+}
+
+/**
+ * The Fountain Section outline, rendered as the tree the hashes describe.
+ *
+ * Depth comes from the node's own level rather than from how deep the recursion
+ * has run, so an outline that skips a rung — `#` straight to `###`, which the
+ * format allows — is still drawn where the writer put it.
+ */
+const SectionOutline: React.FC<SectionOutlineProps> = ({
+  sections, onGoToSection, onGoToScene, query,
+}) => (
+  <>
+    {sections.map((section) => (
+      <div key={`section-${section.sectionIndex}`} className="structure-section">
+        <div
+          className="structure-section-header"
+          style={{ paddingLeft: `${8 + (section.level - 1) * 12}px` }}
+          onClick={() => onGoToSection(section.sectionIndex)}
+          title={section.synopsis || undefined}
+        >
+          <span className="structure-section-level">{'#'.repeat(section.level)}</span>
+          <span className="structure-section-name">
+            {highlightText(section.title || 'Untitled section', query)}
+          </span>
+          {section.scenes.length > 0 && (
+            <span className="structure-section-count">{section.scenes.length}</span>
+          )}
+        </div>
+        {section.synopsis !== '' && (
+          <div
+            className="structure-section-synopsis"
+            style={{ paddingLeft: `${20 + (section.level - 1) * 12}px` }}
+          >
+            {section.synopsis}
+          </div>
+        )}
+        {section.scenes.length > 0 && (
+          <div className="structure-scene-list">
+            {section.scenes.map((scene) => (
+              <div
+                key={`section-scene-${section.sectionIndex}-${scene.sceneIndex}`}
+                className="structure-scene"
+                style={{ paddingLeft: `${20 + (section.level - 1) * 12}px` }}
+                onClick={() => onGoToScene(scene.sceneIndex)}
+              >
+                <span className="structure-scene-num">{scene.sceneIndex + 1}</span>
+                <span className="structure-scene-heading">{scene.heading}</span>
+              </div>
+            ))}
+          </div>
+        )}
+        <SectionOutline
+          sections={section.children}
+          onGoToSection={onGoToSection}
+          onGoToScene={onGoToScene}
+          query={query}
+        />
+      </div>
+    ))}
+  </>
+);
+
 // ── Main component ──────────────────────────────────────────────────────
 
 const SceneNavigator: React.FC<SceneNavigatorProps> = ({ editor, scrollContainer, style }) => {
@@ -354,11 +424,14 @@ const SceneNavigator: React.FC<SceneNavigatorProps> = ({ editor, scrollContainer
   // ── Compute act/sequence structure ──
 
   const structure: ScriptStructure = useMemo(() => {
-    if (!editor) return { acts: [], sceneActMap: new Map(), totalScenes: 0 };
+    const empty: ScriptStructure = {
+      acts: [], sections: [], totalSections: 0, sceneActMap: new Map(), totalScenes: 0,
+    };
+    if (!editor) return empty;
     try {
       return computeScriptStructure(editor.getJSON());
     } catch {
-      return { acts: [], sceneActMap: new Map(), totalScenes: 0 };
+      return empty;
     }
   }, [editor, scenes]);
 
@@ -548,6 +621,40 @@ const SceneNavigator: React.FC<SceneNavigatorProps> = ({ editor, scrollContainer
         }
         return true;
       });
+      editor.chain().focus().setTextSelection(targetPos + 1).run();
+      requestAnimationFrame(() => {
+        const coords = editor.view.coordsAtPos(targetPos + 1);
+        if (scrollContainer) {
+          const containerRect = scrollContainer.getBoundingClientRect();
+          const scrollTo = scrollContainer.scrollTop + (coords.top - containerRect.top) - 60;
+          scrollContainer.scrollTo({ top: scrollTo, behavior: 'auto' });
+        }
+      });
+    },
+    [editor, scrollContainer],
+  );
+
+  /**
+   * Scroll to the nth Section in the document.
+   *
+   * Sections are addressed by their ordinal rather than a stored position for
+   * the same reason scenes are: the structure is rebuilt from the document's
+   * JSON, which carries no ProseMirror positions.
+   */
+  const goToSection = useCallback(
+    (sectionIndex: number) => {
+      if (!editor) return;
+      const { doc } = editor.state;
+      let seen = -1;
+      let targetPos = -1;
+      doc.descendants((node, pos) => {
+        if (node.type.name === 'section') {
+          seen++;
+          if (seen === sectionIndex) { targetPos = pos; return false; }
+        }
+        return true;
+      });
+      if (targetPos < 0) return;
       editor.chain().focus().setTextSelection(targetPos + 1).run();
       requestAnimationFrame(() => {
         const coords = editor.view.coordsAtPos(targetPos + 1);
@@ -923,14 +1030,33 @@ const SceneNavigator: React.FC<SceneNavigatorProps> = ({ editor, scrollContainer
           <div className="navigator-header">
             <span className="navigator-title">Structure</span>
             <span className="scene-count">
-              {structure.acts.filter((a) => a.actNumber > 0).length || '—'} acts
+              {structure.totalSections > 0
+                ? `${structure.totalSections} section${structure.totalSections === 1 ? '' : 's'}`
+                : `${structure.acts.filter((a) => a.actNumber > 0).length || '—'} acts`}
             </span>
           </div>
           <div className="navigator-list">
-            {structure.acts.length === 0 ? (
-              <div className="navigator-empty">
-                No structure yet. Insert an Act Break from the element selector, or start writing scenes.
+            {/* The Section outline, when the script has one. It sits above the
+                acts rather than inside them: Sections and Act Breaks are two
+                separate hierarchies, and a script can use either or both. */}
+            {structure.sections.length > 0 && (
+              <div className="structure-outline">
+                <div className="structure-outline-title">Outline</div>
+                <SectionOutline
+                  sections={structure.sections}
+                  onGoToSection={goToSection}
+                  onGoToScene={goToScene}
+                  query={searchQuery}
+                />
               </div>
+            )}
+            {structure.acts.length === 0 ? (
+              structure.sections.length === 0 && (
+                <div className="navigator-empty">
+                  No structure yet. Add a Section for an outline heading, insert an Act Break from
+                  the element selector, or start writing scenes.
+                </div>
+              )
             ) : (
               structure.acts.map((act) => {
                 const isCollapsed = collapsedActs.has(act.actNumber);

--- a/frontend/src/components/ScreenplayEditor.tsx
+++ b/frontend/src/components/ScreenplayEditor.tsx
@@ -23,6 +23,7 @@ import { HocuspocusProvider } from '@hocuspocus/provider';
 import {
   SceneHeading, Action, Character, Dialogue, Parenthetical,
   Transition, General, Shot, NewAct, EndOfAct, Lyrics,
+  Section, Note,
   ShowEpisode, CastList, FontSize, PasteFormatting, ScriptNoteMark, TagMark,
   FormatOverride, CustomElement, DualDialogue, DualDialogueColumn,
   TitlePage,
@@ -178,7 +179,7 @@ const DEFAULT_NEXT_TYPE: Record<string, string> = {
 const ALL_ELEMENT_TYPES: ElementType[] = [
   'sceneHeading', 'action', 'character', 'dialogue', 'parenthetical',
   'transition', 'general', 'shot', 'newAct', 'endOfAct', 'lyrics',
-  'showEpisode', 'castList',
+  'showEpisode', 'castList', 'section', 'note',
 ];
 
 const SAMPLE_CONTENT = {
@@ -1471,12 +1472,14 @@ const ScreenplayEditor: React.FC = () => {
             general: 'Text...', shot: 'SHOT DESCRIPTION',
             newAct: 'ACT ONE', endOfAct: 'END OF ACT',
             lyrics: 'Lyrics...', showEpisode: 'SHOW TITLE', castList: 'Cast...',
+            section: 'Section name (outline only)', note: 'Note (not printed)',
           };
           return m[node.type.name] || '';
         },
       }),
       SceneHeading, Action, Character, Dialogue, Parenthetical,
       Transition, General, Shot, NewAct, EndOfAct, Lyrics,
+      Section, Note,
       ShowEpisode, CastList, DualDialogue, DualDialogueColumn, TitlePage,
       AvBlock, AvRow, AvCell, AvPara, AvShot, AvDirection, AvKeymap,
       ScriptNoteMark, TagMark,

--- a/frontend/src/editor/extensions/Note.ts
+++ b/frontend/src/editor/extensions/Note.ts
@@ -1,0 +1,36 @@
+import { Node, mergeAttributes } from '@tiptap/core';
+
+/**
+ * `note` — Fountain's `[[ double bracket ]]` note.
+ *
+ * The spec is explicit that a note "stays in the file but not in the PDF", so
+ * it is a non-printing element like `section`, not a line of Action. Imported
+ * as Action the brackets came through as literal characters and the writer's
+ * aside was printed in the middle of a scene.
+ *
+ * This is deliberately *not* the same thing as OpenDraft's script notes, which
+ * are anchored to a run of text and live in the notes panel. A Fountain note
+ * has no anchor — it is a standalone paragraph the writer parked between two
+ * elements — so it is represented as one.
+ */
+export const Note = Node.create({
+  name: 'note',
+  group: 'block',
+  content: 'inline*',
+  defining: true,
+
+  parseHTML() {
+    return [{ tag: 'div[data-type="note"]' }];
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    return [
+      'div',
+      mergeAttributes(HTMLAttributes, {
+        'data-type': 'note',
+        class: 'screenplay-element note',
+      }),
+      0,
+    ];
+  },
+});

--- a/frontend/src/editor/extensions/Section.ts
+++ b/frontend/src/editor/extensions/Section.ts
@@ -1,0 +1,59 @@
+import { Node, mergeAttributes } from '@tiptap/core';
+
+/**
+ * `section` — Fountain's outlining marker (`#`, `##`, `###`, …).
+ *
+ * A Section is structure, not script: it names a part of the story so it can be
+ * found in an outline, and it never appears on the printed page. That is what
+ * separates it from New Act and End of Act, which are act markers a reader is
+ * meant to see. Both exist because Fountain has both, and conflating them was
+ * how `# ACT ONE` ended up printed as a line of Action (issue #82).
+ *
+ * `level` is the number of hashes — 1 is the outermost. The hierarchy is
+ * carried by the level alone, exactly as it is in the file, rather than by
+ * nesting nodes: a Fountain document is free to jump from `#` straight to
+ * `###`, and a tree would have to invent the missing rung to hold it.
+ */
+export const MAX_SECTION_LEVEL = 6;
+
+/** Clamp any incoming depth to a level the schema and stylesheet can hold. */
+export function clampSectionLevel(level: unknown): number {
+  const n = typeof level === 'number' ? level : parseInt(String(level ?? ''), 10);
+  if (!Number.isFinite(n)) return 1;
+  return Math.min(MAX_SECTION_LEVEL, Math.max(1, Math.round(n)));
+}
+
+export const Section = Node.create({
+  name: 'section',
+  group: 'block',
+  content: 'inline*',
+  defining: true,
+
+  addAttributes() {
+    return {
+      level: {
+        default: 1,
+        parseHTML: (element) => clampSectionLevel(element.getAttribute('data-level')),
+        renderHTML: (attributes) => ({ 'data-level': String(clampSectionLevel(attributes.level)) }),
+      },
+      /** Fountain synopsis (`=`) written under this section. Not printed. */
+      synopsis: { default: '' },
+    };
+  },
+
+  parseHTML() {
+    return [{ tag: 'div[data-type="section"]' }];
+  },
+
+  renderHTML({ HTMLAttributes, node }) {
+    const level = clampSectionLevel(node.attrs.level);
+    return [
+      'div',
+      mergeAttributes(HTMLAttributes, {
+        'data-type': 'section',
+        class: `screenplay-element section section-level-${level}`,
+      }),
+      0,
+    ];
+  },
+});

--- a/frontend/src/editor/extensions/index.ts
+++ b/frontend/src/editor/extensions/index.ts
@@ -9,6 +9,8 @@ export { Shot } from './Shot';
 export { NewAct } from './NewAct';
 export { EndOfAct } from './EndOfAct';
 export { Lyrics } from './Lyrics';
+export { Section, clampSectionLevel, MAX_SECTION_LEVEL } from './Section';
+export { Note } from './Note';
 export { ShowEpisode } from './ShowEpisode';
 export { CastList } from './CastList';
 export { DualDialogue, DualDialogueColumn } from './DualDialogue';

--- a/frontend/src/editor/pagination.test.ts
+++ b/frontend/src/editor/pagination.test.ts
@@ -149,3 +149,44 @@ describe('space before comes from the template', () => {
     expect(loose.length).toBeGreaterThan(tight.length);
   });
 });
+
+describe('non-printing elements take no space on the page', () => {
+  const layout = DEFAULT_PAGE_LAYOUT;
+  const linesPerPage = getPageMetrics(layout).linesPerPage;
+
+  /** A run of Action blocks, one line each, filling exactly one page. */
+  const fullPage = () =>
+    Array.from({ length: linesPerPage }, (_, i) => block('action', `Line ${i}.`));
+
+  it('does not push an element onto a second page', () => {
+    // Every Action line is preceded by a blank line, so `linesPerPage / 2`
+    // blocks fill the page. Sections and Notes are never printed — counted like
+    // any other block they would move the break to an element the reader of the
+    // PDF cannot see, and the page count on screen would stop matching the file.
+    const half = fullPage().slice(0, Math.floor(linesPerPage / 2));
+    const withoutOutline = computeBreaks(pmDoc(doc(...half)), layout).breaks;
+    const withOutline = computeBreaks(
+      pmDoc(doc(
+        { ...block('section', 'ACT ONE'), attrs: { level: 1 } },
+        block('note', 'Remember to cut this scene down.'),
+        ...half,
+      )),
+      layout,
+    ).breaks;
+    expect(withoutOutline).toHaveLength(0);
+    expect(withOutline).toHaveLength(0);
+  });
+
+  it('leaves the page a break falls on unchanged', () => {
+    const body = fullPage();
+    const plain = computeBreaks(pmDoc(doc(...body)), layout);
+    const outlined = computeBreaks(
+      pmDoc(doc({ ...block('section', 'ACT ONE'), attrs: { level: 1 } }, ...body)),
+      layout,
+    );
+    expect(outlined.pageCount).toBe(plain.pageCount);
+    // One node further along, because the Section itself is node 0.
+    expect(outlined.breaks.map((b) => b.nodeIndex))
+      .toEqual(plain.breaks.map((b) => b.nodeIndex + 1));
+  });
+});

--- a/frontend/src/editor/pagination.ts
+++ b/frontend/src/editor/pagination.ts
@@ -11,6 +11,7 @@ import { getTextLines } from '../utils/wrapText';
 import { DEFAULT_SPACE_BEFORE, buildSpaceBefore, getSpaceBefore, type SpaceBeforeSource } from '../utils/elementSpacing';
 import { findTitlePageRegion, titlePageAttrsCarryData } from '../utils/titlePageRegion';
 import { useFormattingTemplateStore } from '../stores/formattingTemplateStore';
+import { isNonPrintingType } from '../utils/nonPrinting';
 
 export const paginationPluginKey = new PluginKey('pagination');
 
@@ -265,11 +266,19 @@ export function computeBreaks(doc: PmNode, layout: PageLayout, hints: TemplateHi
     const sb = isFirst ? 0 : (hints.spaceBefore[elementId] ?? 0);
     const lineMul = hints.lineHeightMultiplier[elementId] ?? 1;
     // Images occupy a fixed estimated number of lines (no text to wrap).
-    const fixedLines = typeName === 'screenplayImage'
-      ? Math.max(1, Number(node.attrs?.heightLines) || 8)
-      : undefined;
+    // Sections and Notes are structure, not script — they never reach the page,
+    // so they occupy no lines and claim no space before them. Counted like any
+    // other block they would push the page break somewhere the printed script
+    // has no element at all, and the page count on screen would stop matching
+    // the PDF.
+    const nonPrinting = isNonPrintingType(typeName);
+    const fixedLines = nonPrinting
+      ? 0
+      : typeName === 'screenplayImage'
+        ? Math.max(1, Number(node.attrs?.heightLines) || 8)
+        : undefined;
     nodes.push({
-      typeName, elementId, spaceBefore: sb, text: node.textContent || '',
+      typeName, elementId, spaceBefore: nonPrinting ? 0 : sb, text: node.textContent || '',
       offset, nodeSize: node.nodeSize, lineMul, fixedLines,
       startsNewPage: node.attrs?.startsNewPage === true,
       hasTitleData: titlePageAttrsCarryData(node.attrs as Record<string, unknown> | undefined),
@@ -456,8 +465,11 @@ export function computeSceneLengths(
   doc.forEach((node) => {
     const typeName = node.type.name;
     const cpl = CHARS_PER_LINE[typeName] || 62;
-    const textLines = getTextLines(node.textContent || '', cpl);
-    const sb = nodeIdx === 0 ? 0 : (hints.spaceBefore[typeName] ?? 0);
+    // A Section or Note inside a scene adds nothing to its length, for the same
+    // reason it adds nothing to the page: it is never printed.
+    const nonPrinting = isNonPrintingType(typeName);
+    const textLines = nonPrinting ? 0 : getTextLines(node.textContent || '', cpl);
+    const sb = nodeIdx === 0 || nonPrinting ? 0 : (hints.spaceBefore[typeName] ?? 0);
 
     if (typeName === 'sceneHeading') {
       if (inScene) lengths.push(sceneLines / linesPerPage);
@@ -542,9 +554,12 @@ export function computePageBlocks(
     for (let i = pb.startNode; i <= Math.min(pb.endNode, nodes.length - 1); i++) {
       const node = nodes[i];
       const cpl = CHARS_PER_LINE[node.typeName] || 62;
-      const textLines = getTextLines(node.text, cpl);
-      const sb = firstOnPage ? 0 : (hints.spaceBefore[node.typeName] ?? 0);
-      firstOnPage = false;
+      const nonPrinting = isNonPrintingType(node.typeName);
+      const textLines = nonPrinting ? 0 : getTextLines(node.text, cpl);
+      const sb = firstOnPage || nonPrinting ? 0 : (hints.spaceBefore[node.typeName] ?? 0);
+      // A non-printing block does not count as the first thing on the page —
+      // the element after it still gets its space before.
+      if (!nonPrinting) firstOnPage = false;
 
       blocks.push({
         typeName: node.typeName,

--- a/frontend/src/stores/editorStore.ts
+++ b/frontend/src/stores/editorStore.ts
@@ -164,6 +164,9 @@ export type BuiltInElementType =
   | 'lyrics'
   | 'showEpisode'
   | 'castList'
+  // Fountain's two non-printing structural elements — see utils/nonPrinting.ts.
+  | 'section'
+  | 'note'
   | 'titlePage';
 
 /** Element type id — built-in literal or any custom id declared by a template.
@@ -190,6 +193,8 @@ export const ELEMENT_LABELS: Record<string, string> = {
   lyrics: 'Lyrics',
   showEpisode: 'Show/Episode',
   castList: 'Cast List',
+  section: 'Section (Outline)',
+  note: 'Note (Not printed)',
   titlePage: 'Title Page',
 };
 

--- a/frontend/src/stores/formattingTypes.ts
+++ b/frontend/src/stores/formattingTypes.ts
@@ -119,6 +119,10 @@ export const ELEMENT_DESCRIPTIONS: Record<string, string> = {
   parenthetical: 'A short direction to the actor, in brackets inside a dialogue block.',
   transition: 'How the film moves to the next scene — CUT TO:, DISSOLVE TO:.',
   sceneHeading: 'Where and when a scene takes place — INT./EXT., location, time of day.',
+  section:
+    'An outline heading, from Fountain\u2019s # Section. Structure only: it shows in the '
+    + 'navigator but never on the printed page. Use New Act for an act break a reader should see.',
+  note: 'An aside to yourself, kept in the file and left off the printed page.',
 };
 
 /** The 13 built-in element type ids (matches ElementType union). */
@@ -136,6 +140,8 @@ export const BUILT_IN_ELEMENT_IDS: readonly string[] = [
   'lyrics',
   'showEpisode',
   'castList',
+  'section',
+  'note',
 ] as const;
 
 /**
@@ -156,6 +162,8 @@ export const ELEMENT_CSS_CLASS: Record<string, string> = {
   lyrics: 'lyrics',
   showEpisode: 'show-episode',
   castList: 'cast-list',
+  section: 'section',
+  note: 'note',
 };
 
 /** Sentinel ID for the industry standard template (never stored in DB). */

--- a/frontend/src/stores/industryStandardTemplate.ts
+++ b/frontend/src/stores/industryStandardTemplate.ts
@@ -7,7 +7,7 @@
 
 import type { FormattingTemplate, FormattingElementRule } from './formattingTypes';
 import { INDUSTRY_STANDARD_ID } from './formattingTypes';
-import { titlePageRules } from './templates/_helpers';
+import { outlineRules, titlePageRules } from './templates/_helpers';
 
 function rule(
   id: string,
@@ -146,6 +146,7 @@ export const INDUSTRY_STANDARD_TEMPLATE: FormattingTemplate = {
       nextOnEnter: 'castList',
       placeholder: 'Cast...',
     }),
+    ...outlineRules(),
     // The title page's own elements, so its typography is part of the template
     // rather than fixed in the stylesheet.
     ...titlePageRules(),

--- a/frontend/src/stores/templates/_helpers.ts
+++ b/frontend/src/stores/templates/_helpers.ts
@@ -44,6 +44,37 @@ export function disabled(id: string, label: string): FormattingElementRule {
 }
 
 /**
+ * Fountain's two non-printing structural elements, shared by every script type.
+ *
+ * They carry a formatting rule like any other element so the Template Editor,
+ * the element picker and the Enter/Tab flow can see them — but the formatting
+ * is screen-only. Nothing they say reaches the page: pagination and every
+ * exporter skip them (see utils/nonPrinting.ts), which is the whole point of
+ * a Section as against a New Act.
+ *
+ * `nextOnEnter: 'action'` because a section titles what follows it — the writer
+ * types "# ACT ONE" and then starts writing the script, not another heading.
+ */
+export function outlineRules(): Record<string, FormattingElementRule> {
+  return {
+    section: rule('section', 'Section (Outline)', true, {
+      bold: true,
+      marginTop: 12,
+      nextOnEnter: 'action',
+      nextOnTab: 'action',
+      placeholder: 'Section name (outline only)',
+    }),
+    note: rule('note', 'Note (Not printed)', true, {
+      italic: true,
+      marginTop: 12,
+      nextOnEnter: 'action',
+      nextOnTab: 'action',
+      placeholder: 'Note (not printed)',
+    }),
+  };
+}
+
+/**
  * The default title-page rules, matching what screenplay.css has always drawn:
  * a bold uppercase centred title, a centred credit, the draft flush left, and
  * the contact and copyright blocks flush right.

--- a/frontend/src/stores/templates/avScriptTemplate.ts
+++ b/frontend/src/stores/templates/avScriptTemplate.ts
@@ -7,7 +7,7 @@
  */
 
 import type { FormattingTemplate, StarterNode } from '../formattingTypes';
-import { rule, disabled } from './_helpers';
+import { rule, disabled, outlineRules } from './_helpers';
 
 export const AV_SCRIPT_ID = '__av_script__';
 
@@ -96,6 +96,7 @@ export const AV_SCRIPT_TEMPLATE: FormattingTemplate = {
       nextOnEnter: 'action',
       placeholder: 'TITLE',
     }),
+    ...outlineRules(),
     castList: disabled('castList', 'Cast List'),
     // Inner AV-cell paragraphs — formatting only, since they live inside avCell.
     avPara: rule('avPara', 'Audio/Video Body', false, {

--- a/frontend/src/stores/templates/multicamSitcomTemplate.ts
+++ b/frontend/src/stores/templates/multicamSitcomTemplate.ts
@@ -11,7 +11,7 @@
  */
 
 import type { FormattingTemplate, StarterNode } from '../formattingTypes';
-import { rule, disabled } from './_helpers';
+import { rule, disabled, outlineRules } from './_helpers';
 
 export const MULTICAM_SITCOM_ID = '__multicam_sitcom__';
 
@@ -130,6 +130,7 @@ export const MULTICAM_SITCOM_TEMPLATE: FormattingTemplate = {
       nextOnEnter: 'newAct',
       placeholder: 'SHOW TITLE',
     }),
+    ...outlineRules(),
     castList: rule('castList', 'Cast List', true, {
       textTransform: 'uppercase',
       leftIndent: 1.75,

--- a/frontend/src/stores/templates/oneHourDramaTemplate.ts
+++ b/frontend/src/stores/templates/oneHourDramaTemplate.ts
@@ -7,7 +7,7 @@
  */
 
 import type { FormattingTemplate, StarterNode } from '../formattingTypes';
-import { rule } from './_helpers';
+import { rule, outlineRules } from './_helpers';
 
 export const ONE_HOUR_DRAMA_ID = '__one_hour_drama__';
 
@@ -122,6 +122,7 @@ export const ONE_HOUR_DRAMA_TEMPLATE: FormattingTemplate = {
       nextOnEnter: 'newAct',
       placeholder: 'SHOW TITLE',
     }),
+    ...outlineRules(),
     castList: rule('castList', 'Cast List', true, {
       textTransform: 'uppercase',
       leftIndent: 1.75,

--- a/frontend/src/stores/templates/radioPlayTemplate.ts
+++ b/frontend/src/stores/templates/radioPlayTemplate.ts
@@ -9,7 +9,7 @@
  */
 
 import type { FormattingTemplate, StarterNode } from '../formattingTypes';
-import { rule, disabled } from './_helpers';
+import { rule, disabled, outlineRules } from './_helpers';
 
 export const RADIO_PLAY_ID = '__radio_play__';
 
@@ -105,6 +105,7 @@ export const RADIO_PLAY_TEMPLATE: FormattingTemplate = {
       nextOnEnter: 'sceneHeading',
       placeholder: 'SHOW TITLE',
     }),
+    ...outlineRules(),
     castList: disabled('castList', 'Cast List'),
     // Custom: SFX cue, all caps
     soundEffect: rule('soundEffect', 'Sound Effect', false, {

--- a/frontend/src/stores/templates/stagePlayTemplate.ts
+++ b/frontend/src/stores/templates/stagePlayTemplate.ts
@@ -9,7 +9,7 @@
  */
 
 import type { FormattingTemplate, StarterNode } from '../formattingTypes';
-import { rule, disabled } from './_helpers';
+import { rule, disabled, outlineRules } from './_helpers';
 
 export const STAGE_PLAY_ID = '__stage_play__';
 
@@ -105,6 +105,7 @@ export const STAGE_PLAY_TEMPLATE: FormattingTemplate = {
       placeholder: 'Lyrics...',
     }),
     showEpisode: disabled('showEpisode', 'Show/Episode'),
+    ...outlineRules(),
     castList: disabled('castList', 'Cast List'),
     // Custom: italic, parenthesized stage direction set off from dialogue
     stageDirection: rule('stageDirection', 'Stage Direction', false, {

--- a/frontend/src/styles/screenplay.css
+++ b/frontend/src/styles/screenplay.css
@@ -1655,6 +1655,63 @@ body {
 .structure-act {
   border-bottom: 1px solid var(--fd-overlay-subtle);
 }
+/* ── Section outline (Structure tab) ──────────────────────────────────
+   Fountain Sections, drawn as the tree their hashes describe. Depth comes from
+   the node's own level via an inline padding, not from nesting, so an outline
+   that jumps from # to ### still lines up where the writer put it. */
+.structure-outline {
+  border-bottom: 1px solid var(--fd-border);
+  padding-bottom: 6px;
+  margin-bottom: 6px;
+}
+.structure-outline-title {
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--fd-text-muted);
+  padding: 10px 12px 4px;
+}
+.structure-section-header {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 5px 12px;
+  cursor: pointer;
+}
+.structure-section-header:hover { background: var(--fd-overlay-subtle); }
+.structure-section-level {
+  font-family: var(--fd-mono, monospace);
+  font-size: 11px;
+  color: var(--fd-accent, #3b82f6);
+  flex-shrink: 0;
+}
+.structure-section-name {
+  flex: 1;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--fd-text);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.structure-section-count {
+  font-size: 11px;
+  color: var(--fd-text-muted);
+  background: var(--fd-overlay-light);
+  border-radius: 8px;
+  padding: 1px 6px;
+  flex-shrink: 0;
+}
+.structure-section-synopsis {
+  font-size: 11px;
+  font-style: italic;
+  color: var(--fd-text-muted);
+  padding-right: 12px;
+  padding-bottom: 4px;
+  white-space: pre-wrap;
+}
+
 .structure-act-header {
   display: flex;
   align-items: center;
@@ -2156,6 +2213,39 @@ body {
   font-style: italic;
   padding-left: calc(2.50in - var(--pl, 1.50in));
   padding-right: calc(var(--pw, 8.26in) - 6.00in - var(--pr, 0.76in));
+}
+
+/* ── Non-printing structure: Fountain Sections and Notes ──────────────
+   Both are outline, not script. They are drawn distinctly so a writer can see
+   at a glance that they are not part of the page, and they are removed from
+   print entirely by the @media print rule further down — the same decision
+   pagination and the PDF/DOCX/FDX/OSF exporters make in code. */
+.section {
+  font-weight: bold;
+  color: var(--fd-accent, #3b82f6);
+  border-left: 3px solid var(--fd-accent, #3b82f6);
+  padding-left: 8px;
+  margin-top: 12pt;
+  letter-spacing: 0.02em;
+}
+
+/* Depth by indent and weight, so a nested outline reads as one. Level is
+   carried on the node, not by nesting — a Fountain file may jump from # to ###
+   and the outline has to hold that without inventing the middle rung. */
+.section[data-level="1"] { font-size: 1.08em; }
+.section[data-level="2"] { margin-left: 0.25in; opacity: 0.95; }
+.section[data-level="3"] { margin-left: 0.50in; opacity: 0.9; }
+.section[data-level="4"] { margin-left: 0.75in; opacity: 0.85; }
+.section[data-level="5"] { margin-left: 1.00in; opacity: 0.8; }
+.section[data-level="6"] { margin-left: 1.25in; opacity: 0.75; }
+
+.note {
+  font-style: italic;
+  color: var(--fd-text-dim, #8a8a8a);
+  background: var(--fd-note-bg, rgba(244, 211, 94, 0.10));
+  border-left: 3px solid var(--fd-note-border, #f4d35e);
+  padding: 2px 8px;
+  margin-top: 12pt;
 }
 
 /* Show/Episode */
@@ -9899,6 +9989,12 @@ html.android .version-history-panel {
 
   /* Let the browser handle page breaks */
   .tiptap .ProseMirror > * { page-break-inside: avoid; }
+
+  /* Fountain's non-printing elements. The spec is explicit that a Section and
+     a Note stay in the file and off the page, so print drops them — matching
+     what pagination counted and what the exporters write. */
+  .screenplay-element.section,
+  .screenplay-element.note { display: none !important; }
 }
 
 /* ── Collaboration ────────────────────────────────────────────────── */

--- a/frontend/src/test/screenplaySchema.ts
+++ b/frontend/src/test/screenplaySchema.ts
@@ -23,6 +23,7 @@ import { ScreenplayHardBreak, HardBreakLeafText } from '../editor/extensions/Scr
 import {
   SceneHeading, Action, Character, Dialogue, Parenthetical, Transition,
   General, Shot, NewAct, EndOfAct, Lyrics, ShowEpisode, CastList,
+  Section, Note,
   TitlePage, CustomElement,
   DualDialogue, DualDialogueColumn,
   AvBlock, AvRow, AvCell, AvPara, AvShot, AvDirection,
@@ -37,6 +38,7 @@ export const testSchema = getSchema([
   Bold, Italic, Underline, Strike,
   SceneHeading, Action, Character, Dialogue, Parenthetical, Transition,
   General, Shot, NewAct, EndOfAct, Lyrics, ShowEpisode, CastList,
+  Section, Note,
   TitlePage, CustomElement,
   DualDialogue, DualDialogueColumn,
   AvBlock, AvRow, AvCell, AvPara, AvShot, AvDirection,

--- a/frontend/src/utils/docxExporter.ts
+++ b/frontend/src/utils/docxExporter.ts
@@ -34,6 +34,7 @@ import { getForceBreakIds, jsonStartsOwnPage } from './pageBreaks';
 import { getSpaceBefore, DEFAULT_SPACE_BEFORE } from './elementSpacing';
 import { sanitizeExportFilename } from './exportFilename';
 import { findTitlePageRegion, titlePageAttrsCarryData } from './titlePageRegion';
+import { isNonPrintingType } from './nonPrinting';
 
 // --- Layout constants (mirror pdfExporter.ts) ---
 
@@ -408,6 +409,8 @@ export async function exportDocx(
   );
   const hasTitlePage = region.isReal;
   docNodes.forEach((node, index) => {
+    // Sections and Notes never reach the page — see utils/nonPrinting.ts.
+    if (isNonPrintingType(node.type)) return;
     if (hasTitlePage && index < region.length) {
       titleRegionNodes.push(node);
       return;

--- a/frontend/src/utils/elementSpacing.ts
+++ b/frontend/src/utils/elementSpacing.ts
@@ -40,6 +40,9 @@ export const DEFAULT_SPACE_BEFORE: Record<string, number> = {
   sceneHeading: 2, action: 1, character: 1, dialogue: 0,
   parenthetical: 0, transition: 1, general: 0, shot: 1,
   newAct: 2, endOfAct: 2, lyrics: 0, showEpisode: 1, castList: 0,
+  // On screen they get a line of air like any other block; on the page they
+  // take none, because pagination skips them outright — see NON_PRINTING_TYPES.
+  section: 1, note: 1,
 };
 
 /** The subset of a formatting template this module reads. */

--- a/frontend/src/utils/fdxExporter.ts
+++ b/frontend/src/utils/fdxExporter.ts
@@ -5,6 +5,7 @@ import { resolveHeaderFooter } from '../stores/editorStore';
 import { CUSTOM_TYPE_TO_FDX } from './fdxParser';
 import { jsonBlockText } from './nodeText';
 import { sanitizeExportFilename } from './exportFilename';
+import { isNonPrintingType } from './nonPrinting';
 
 const NODE_TO_FDX: Record<string, string> = {
   sceneHeading: 'Scene Heading',
@@ -452,6 +453,10 @@ export function exportFDX(doc: JSONContent, title: string = 'Untitled', characte
   if (doc.content) {
     for (const node of doc.content) {
       // FDX has no representation for inserted images — skip them.
+      // Fountain's non-printing structure has no Final Draft equivalent that
+      // stays off the page — a Paragraph of any type prints — so it is left out
+      // rather than smuggled in as Action.
+      if (isNonPrintingType(node.type)) continue;
       if (node.type === 'screenplayImage') continue;
       // The title page has already been written to <TitlePage><Content>, which
       // is where Final Draft looks for it. Emitting these here as well put the

--- a/frontend/src/utils/fountainExporter.ts
+++ b/frontend/src/utils/fountainExporter.ts
@@ -2,6 +2,7 @@
 import type { JSONContent } from '@tiptap/react';
 import { jsonBlockRuns, mergeRuns, singleLine } from './nodeText';
 import { sanitizeExportFilename } from './exportFilename';
+import { clampSectionLevel } from '../editor/extensions/Section';
 
 /**
  * Escape the characters Fountain reads as emphasis markup, so text the writer
@@ -110,8 +111,24 @@ const SCENE_HEADING_RE = /^(INT\.|EXT\.|EST\.|INT\.\/EXT\.|I\/E\.)/;
 /** The parser's all-caps-ending-in-`TO:` transition heuristic. */
 const TRANSITION_RE = /^[A-Z\s]+TO:$/;
 
-/** Leading characters the parser reads as a forcing sigil or block marker. */
-const SIGIL_RE = /^[!~.>@=]/;
+/**
+ * Leading characters the parser reads as a forcing sigil or block marker.
+ *
+ * `#` joined the list when Sections did: without it a line of Action that opens
+ * with a hash — a hashtag, a scene number a writer typed by hand — came back as
+ * a section heading and vanished from the printed page.
+ */
+const SIGIL_RE = /^[!~.>@=#]/;
+
+/**
+ * The opening of a Fountain note, which has no escape in the spec — so Action
+ * containing one has to be forced with `!`, or the brackets and everything
+ * between them are lifted out of the line as an annotation on the way back in.
+ *
+ * The boneyard's `/*` needs no equivalent: `escapeFountain` backslashes every
+ * asterisk, so the marker can never survive into the output intact.
+ */
+const NOTE_MARKER_RE = /\[\[/;
 
 /** Mirrors `isCharacterLine` in fountainParser. */
 function parsesAsCharacter(line: string): boolean {
@@ -135,6 +152,7 @@ function actionText(text: string): string {
       if (trimmed === '') return line;
       const ambiguous =
         SIGIL_RE.test(trimmed) ||
+        NOTE_MARKER_RE.test(trimmed) ||
         SCENE_HEADING_RE.test(trimmed.toUpperCase()) ||
         TRANSITION_RE.test(trimmed) ||
         parsesAsCharacter(trimmed);
@@ -190,6 +208,36 @@ function characterLine(node: JSONContent, suffix = ''): string {
   return `${needsForce ? '@' : ''}${cue}${suffix}`;
 }
 
+/**
+ * Elements that continue the dialogue block they are in.
+ *
+ * Fountain ends a dialogue block at a blank line, so a blank line may only be
+ * written where the block is actually meant to end. The exporter used to put
+ * one after every Dialogue node — and a speech is several nodes whenever it
+ * came from the Fountain parser, which makes one node per line. Saved and
+ * reopened, every line of a speech after the first came back as Action.
+ */
+const DIALOGUE_FAMILY = new Set(['dialogue', 'parenthetical', 'lyrics']);
+
+/** Does the block after this one belong to the same dialogue block? */
+function continuesDialogue(next: JSONContent | undefined): boolean {
+  return !!next && DIALOGUE_FAMILY.has(next.type ?? '');
+}
+
+/**
+ * The `=` lines for an element's synopsis.
+ *
+ * A synopsis is stored as one string and may hold several lines — the parser
+ * files every `=` line it finds under the same heading. Each needs its own `=`
+ * on the way out: a raw newline would end the synopsis and turn the rest into
+ * Action.
+ */
+function synopsisLines(node: JSONContent): string[] {
+  const synopsis = node.attrs?.synopsis;
+  if (typeof synopsis !== 'string' || synopsis.trim() === '') return [];
+  return synopsis.split('\n').map((line) => `= ${line.trim()}`);
+}
+
 export function exportFountain(doc: JSONContent): string {
   const lines: string[] = [];
 
@@ -215,8 +263,9 @@ export function exportFountain(doc: JSONContent): string {
     lines.push('');
   }
 
-  for (const node of doc.content) {
+  doc.content.forEach((node, index) => {
     const text = getTextContent(node);
+    const next = doc.content?.[index + 1];
 
     // A manual page break before this element — Fountain spells it `===`.
     if (node.attrs?.startsNewPage && node.type !== 'titlePage') {
@@ -235,13 +284,36 @@ export function exportFountain(doc: JSONContent): string {
       case 'sceneHeading':
         lines.push('');
         lines.push(sceneHeadingLine(node));
-        if (node.attrs?.synopsis) {
-          lines.push(`= ${node.attrs.synopsis}`);
-        }
+        lines.push(...synopsisLines(node));
         lines.push('');
         break;
       case 'action':
+        // Centred Action is Fountain's `>text<`, and the only way to say
+        // "centred" in the format. Written as plain Action it came back flush
+        // left, so the centring survived neither a save nor a re-open.
+        if (node.attrs?.textAlign === 'center') {
+          lines.push('');
+          lines.push(`> ${singleLine(text).trim()} <`);
+          lines.push('');
+          break;
+        }
         lines.push(actionText(text));
+        lines.push('');
+        break;
+      // Fountain's two non-printing elements. Neither is Action: written as
+      // Action a Section prints on the page it exists to stay off, which is
+      // what issue #82 saw on the way in.
+      case 'section': {
+        const level = clampSectionLevel(node.attrs?.level);
+        lines.push('');
+        lines.push(`${'#'.repeat(level)} ${lineText(node)}`.trimEnd());
+        lines.push(...synopsisLines(node));
+        lines.push('');
+        break;
+      }
+      case 'note':
+        lines.push('');
+        lines.push(`[[${text.trim()}]]`);
         lines.push('');
         break;
       case 'general':
@@ -259,7 +331,7 @@ export function exportFountain(doc: JSONContent): string {
       }
       case 'dialogue':
         lines.push(dialogueText(node));
-        lines.push('');
+        if (!continuesDialogue(next)) lines.push('');
         break;
       case 'transition':
         lines.push('');
@@ -285,7 +357,7 @@ export function exportFountain(doc: JSONContent): string {
         if (node.content) {
           node.content.forEach((col, colIndex) => {
             if (col.type === 'dualDialogueColumn' && col.content) {
-              for (const child of col.content) {
+              col.content.forEach((child, childIndex) => {
                 if (child.type === 'character') {
                   lines.push('');
                   // Second column character gets ^ marker — it must stay on the
@@ -296,9 +368,9 @@ export function exportFountain(doc: JSONContent): string {
                   lines.push(p.startsWith('(') ? p : `(${p})`);
                 } else if (child.type === 'dialogue') {
                   lines.push(dialogueText(child));
-                  lines.push('');
+                  if (!continuesDialogue(col.content?.[childIndex + 1])) lines.push('');
                 }
-              }
+              });
             }
           });
         }
@@ -307,7 +379,7 @@ export function exportFountain(doc: JSONContent): string {
         lines.push(text);
         break;
     }
-  }
+  });
 
   return lines.join('\n');
 }

--- a/frontend/src/utils/fountainParser.ts
+++ b/frontend/src/utils/fountainParser.ts
@@ -1,6 +1,8 @@
 // Fountain markup format parser
 // Spec: https://fountain.io/syntax
 import { buildTitlePageBlocks, type TitlePageFields } from './titlePageBlocks';
+import { clampSectionLevel } from '../editor/extensions/Section';
+import { isNonPrintingType } from './nonPrinting';
 
 interface TipTapMark {
   type: string;
@@ -102,9 +104,146 @@ function parseTitlePage(lines: string[]): { next: number; nodes: TipTapNode[] } 
  */
 const LINE_SEPARATORS = /\r\n?|\u2028|\u2029|\u0085/g;
 
-/** Split text into lines, whichever separator convention it arrived with. */
+/**
+ * Split text into lines, whichever separator convention it arrived with.
+ *
+ * The commented-out boneyard goes first and multi-line notes are folded onto a
+ * single line, both before anything is split — each can span lines, and every
+ * other rule in this parser reads one line at a time.
+ */
 function splitLines(text: string): string[] {
-  return text.replace(/^\uFEFF/, '').replace(LINE_SEPARATORS, '\n').split('\n');
+  const normalised = text.replace(/^\uFEFF/, '').replace(LINE_SEPARATORS, '\n');
+  return foldNotes(stripBoneyard(normalised)).split('\n');
+}
+
+/**
+ * Remove the boneyard: everything between a `/*` marker and its closing
+ * counterpart, which the spec defines as text that is commented out and "will
+ * not be included" in the script.
+ *
+ * The newlines the comment spanned are kept. Deleting them outright would pull
+ * whatever followed the closing marker up onto the line before it, so a
+ * boneyard placed between a scene heading and its action would silently weld
+ * the two into one line. What is commented out disappears; what is not keeps
+ * its own line.
+ *
+ * An unterminated `/*` matches nothing and is left as literal text, rather than
+ * swallowing the rest of the script.
+ */
+function stripBoneyard(text: string): string {
+  return text.replace(/\/\*[\s\S]*?\*\//g, (block) => block.replace(/[^\n]/g, ''));
+}
+
+/**
+ * A Fountain note: `[[ … ]]`, which the spec says stays in the file but not in
+ * the printed script.
+ */
+const NOTE_PATTERN = /\[\[([\s\S]*?)\]\]/g;
+
+/**
+ * Fold a note that runs over several lines onto one.
+ *
+ * The spec allows a note to span lines, but every other rule here reads one
+ * line at a time — so an unfolded note left its opening `[[` on a line of its
+ * own, which then parsed as Action, and its closing `]]` on another. Only the
+ * newlines *inside* the brackets are collapsed; the line the note sits on is
+ * otherwise untouched.
+ */
+function foldNotes(text: string): string {
+  return text.replace(NOTE_PATTERN, (note) => note.replace(/\s*\n\s*/g, ' '));
+}
+
+/**
+ * Split a line into the text that remains once its notes are removed, and the
+ * notes themselves.
+ *
+ * Notes are not printed, so they cannot stay in the line — left in place the
+ * brackets came through as literal characters in the middle of a scene. They
+ * are not thrown away either: each becomes a `note` block of its own, emitted
+ * straight after the element it annotated, which is where the writer put it.
+ */
+function extractNotes(line: string): { text: string; notes: string[] } {
+  const notes: string[] = [];
+  const text = line.replace(NOTE_PATTERN, (_, body: string) => {
+    const note = body.trim();
+    if (note !== '') notes.push(note);
+    return '';
+  });
+  return { text, notes };
+}
+
+/** Section heading: one or more leading hashes, e.g. `# ACT ONE`, `## Sequence`. */
+const SECTION_PATTERN = /^(#+)\s*(.*)$/;
+
+/**
+ * A synopsis line: a leading `=` that is not the start of a `===` page break.
+ *
+ * Two equals signs are neither, and stay Action rather than becoming a synopsis
+ * whose text is a stray `=`.
+ */
+const SYNOPSIS_PATTERN = /^=(?!=)\s*(.*)$/;
+
+/** The elements a synopsis can be filed under. */
+const SYNOPSIS_TARGETS = new Set(['sceneHeading', 'section']);
+
+/**
+ * Lines with their notes lifted out, and the notes keyed by the line they came
+ * from. `-1` holds any note that appeared before the first line of content.
+ */
+interface PreparedLines {
+  lines: string[];
+  notes: Map<number, string[]>;
+}
+
+/**
+ * Lift every note out of the text before parsing begins.
+ *
+ * A line that held nothing but a note is *removed*, not blanked. Fountain reads
+ * a blank line as structure — it ends a dialogue block and it is half the test
+ * for a character cue — so leaving one behind where a note used to be would
+ * change how the lines around it parse. A note parked between a cue and its
+ * first line of dialogue would have cut the block in two and dropped the
+ * dialogue out as Action.
+ *
+ * The notes from a removed line are filed against the line above, so they are
+ * emitted after the element they were written next to.
+ */
+function prepareLines(text: string): PreparedLines {
+  const lines: string[] = [];
+  const notes = new Map<number, string[]>();
+
+  const file = (index: number, found: string[]) => {
+    const existing = notes.get(index);
+    if (existing) existing.push(...found);
+    else notes.set(index, [...found]);
+  };
+
+  for (const raw of splitLines(text)) {
+    const { text: stripped, notes: found } = extractNotes(raw);
+    if (found.length > 0 && stripped.trim() === '') {
+      file(lines.length - 1, found);
+      continue;
+    }
+    lines.push(stripped);
+    if (found.length > 0) file(lines.length - 1, found);
+  }
+
+  return { lines, notes };
+}
+
+/**
+ * The nearest scene heading or section already parsed, or null.
+ *
+ * The spec puts synopses "anywhere within the screenplay", so one does not have
+ * to sit directly under the heading it describes. OpenDraft stores a synopsis
+ * on the element it belongs to, which makes the nearest heading or section
+ * above it the right home.
+ */
+function lastSynopsisTarget(nodes: TipTapNode[]): TipTapNode | null {
+  for (let i = nodes.length - 1; i >= 0; i--) {
+    if (SYNOPSIS_TARGETS.has(nodes[i].type)) return nodes[i];
+  }
+  return null;
 }
 
 /**
@@ -142,7 +281,7 @@ function isTransitionLine(trimmed: string): boolean {
 }
 
 export function parseFountain(text: string): TipTapNode {
-  const lines = splitLines(text);
+  const { lines, notes: noteLines } = prepareLines(text);
   const singleSpaced = isSingleSpaced(lines);
   const nodes: TipTapNode[] = [];
   let i = 0;
@@ -156,14 +295,33 @@ export function parseFountain(text: string): TipTapNode {
   let pendingPageBreak = false;
 
   const push = (node: TipTapNode) => {
-    if (pendingPageBreak) {
+    // Never onto a section or a note: neither is printed, so starting a page at
+    // one would move the break somewhere the reader cannot see it. The break
+    // stays pending and lands on the next element that does reach the page.
+    if (pendingPageBreak && !isNonPrintingType(node.type)) {
       node.attrs = { ...node.attrs, startsNewPage: true };
       pendingPageBreak = false;
     }
     nodes.push(node);
   };
 
+  // Notes are emitted once the line they were lifted from has been parsed, so
+  // each lands after the element it annotated whichever rule claimed the line —
+  // including the multi-line ones, where a dialogue block consumes several at
+  // once. Pushed straight onto `nodes`: a pending page break belongs to the
+  // next printed element, not to a note that happens to precede it.
+  let flushedThrough = -2;
+  const flushNotesBefore = (limit: number) => {
+    while (flushedThrough < limit) {
+      flushedThrough++;
+      for (const note of noteLines.get(flushedThrough) ?? []) {
+        nodes.push(makeNode('note', note));
+      }
+    }
+  };
+
   while (i < lines.length) {
+    flushNotesBefore(i - 1);
     const line = lines[i];
     const trimmed = line.trim();
 
@@ -180,11 +338,36 @@ export function parseFountain(text: string): TipTapNode {
       continue;
     }
 
-    // Synopsis line: starts with = (must follow a scene heading)
-    if (trimmed.startsWith('= ') && nodes.length > 0 && nodes[nodes.length - 1].type === 'sceneHeading') {
-      const prev = nodes[nodes.length - 1];
-      if (!prev.attrs) prev.attrs = {};
-      prev.attrs.synopsis = trimmed.substring(2).trim();
+    // Section: one or more leading hashes. Fountain's outlining marker, and
+    // structure rather than script — it is not printed. Nothing else can claim
+    // a line that opens with `#`, so this can be settled before the forcing
+    // rules below.
+    const section = SECTION_PATTERN.exec(trimmed);
+    if (section) {
+      const node = makeNode('section', section[2].trim());
+      node.attrs = { ...node.attrs, level: clampSectionLevel(section[1].length) };
+      push(node);
+      i++;
+      continue;
+    }
+
+    // Synopsis: filed on the nearest scene heading or section above it, since
+    // the spec allows one anywhere. With neither above it there is nothing to
+    // file it on, and it becomes a note — still off the page, still in the file,
+    // rather than printed as a line of Action.
+    const synopsis = SYNOPSIS_PATTERN.exec(trimmed);
+    if (synopsis) {
+      const body = synopsis[1].trim();
+      const target = lastSynopsisTarget(nodes);
+      if (target) {
+        const existing = typeof target.attrs?.synopsis === 'string' ? target.attrs.synopsis : '';
+        target.attrs = {
+          ...target.attrs,
+          synopsis: existing === '' ? body : `${existing}\n${body}`,
+        };
+      } else if (body !== '') {
+        nodes.push(makeNode('note', body));
+      }
       i++;
       continue;
     }
@@ -283,6 +466,9 @@ export function parseFountain(text: string): TipTapNode {
     push(makeNode('action', actionIndent(line)));
     i++;
   }
+
+  // Anything filed against the last lines of the document.
+  flushNotesBefore(lines.length);
 
   // Post-process: merge dual dialogue pairs
   const merged = mergeDualDialogue(nodes);
@@ -482,9 +668,10 @@ function looksLikeCue(line: string): boolean {
  */
 function opensHardElement(trimmed: string): boolean {
   if (trimmed === '') return true;
-  // Forced action, character, transition/centred text, and page break. `~`
-  // (lyrics) is deliberately absent: lyrics belong inside a dialogue block.
-  if (/^[!@>=]/.test(trimmed)) return true;
+  // Forced action, character, transition/centred text, page break, synopsis,
+  // and a section heading. `~` (lyrics) is deliberately absent: lyrics belong
+  // inside a dialogue block.
+  if (/^[!@>=#]/.test(trimmed)) return true;
   // Forced scene heading — `.INT` and not an ellipsis.
   if (/^\.[^.]/.test(trimmed)) return true;
   return isSceneHeadingLine(trimmed) || isTransitionLine(trimmed);
@@ -611,6 +798,22 @@ function collectDialogueBlock(
     const trimmed = line.trim();
 
     if (trimmed === '') {
+      // Two or more spaces on an otherwise blank line is the spec's way of
+      // saying the blank line is deliberate and the block carries on. It is
+      // also exactly what this app's own exporter writes for a paragraph break
+      // inside dialogue — so without this, a `.fountain` saved by OpenDraft and
+      // reopened lost every line of a speech after its first break, as Action.
+      if (/^[ \t]{2,}$/.test(line)) {
+        push(makeNode('dialogue', ''));
+        i++;
+        continue;
+      }
+      break;
+    }
+
+    // A section heading is structure, not speech: it ends the block wherever it
+    // lands, blank line above it or not.
+    if (SECTION_PATTERN.test(trimmed)) {
       break;
     }
 

--- a/frontend/src/utils/fountainStructure.test.ts
+++ b/frontend/src/utils/fountainStructure.test.ts
@@ -1,0 +1,330 @@
+/**
+ * Fountain's non-printing structure: Sections, Synopses, Notes and the
+ * boneyard.
+ *
+ * All four are in the spec and none of them was implemented, so each arrived as
+ * a line of Action — `# ACT ONE` printed in the middle of the script, `[[ ]]`
+ * brackets in the middle of a scene, commented-out text uncommented. Issue #82
+ * reported the first of them after the paste parser itself was fixed.
+ */
+import { describe, it, expect } from 'vitest';
+import { parseFountain } from './fountainParser';
+import { exportFountain } from './fountainExporter';
+import { computeScriptStructure } from './scriptStructure';
+import { doc, block } from '../test/screenplaySchema';
+import type { JSONContent } from '@tiptap/react';
+
+interface Node {
+  type: string;
+  content?: { type: string; text?: string }[];
+  attrs?: Record<string, unknown>;
+}
+
+const parse = (text: string) => parseFountain(text).content as Node[];
+const types = (nodes: Node[]) => nodes.map((n) => n.type);
+const textOf = (node: Node) => (node.content ?? []).map((c) => c.text ?? '\n').join('');
+
+describe('parseFountain — sections', () => {
+  it('reads a single hash as a level 1 section, not Action', () => {
+    const [node] = parse('# ACT ONE\n');
+    expect(node.type).toBe('section');
+    expect(textOf(node)).toBe('ACT ONE');
+    expect(node.attrs?.level).toBe(1);
+  });
+
+  it('keeps the depth of a nested section', () => {
+    const nodes = parse('# ACT ONE\n\n## Sequence A\n\n### Beat one\n');
+    expect(types(nodes)).toEqual(['section', 'section', 'section']);
+    expect(nodes.map((n) => n.attrs?.level)).toEqual([1, 2, 3]);
+  });
+
+  it('clamps a depth past the deepest level the schema holds', () => {
+    const [node] = parse('######## Very deep\n');
+    expect(node.type).toBe('section');
+    expect(node.attrs?.level).toBe(6);
+  });
+
+  it('reads a section with no title', () => {
+    const [node] = parse('#\n');
+    expect(node.type).toBe('section');
+    expect(textOf(node)).toBe('');
+  });
+
+  it('does not swallow the scene under a section', () => {
+    const nodes = parse('# ACT ONE\n\nINT. HOUSE - DAY\n\nSam waits.\n');
+    expect(types(nodes)).toEqual(['section', 'sceneHeading', 'action']);
+  });
+
+  it('ends a dialogue block at a section', () => {
+    const nodes = parse('SAM\nI am done.\n# ACT TWO\n');
+    expect(types(nodes)).toEqual(['character', 'dialogue', 'section']);
+  });
+
+  it('leaves an all-caps section out of the character heuristic', () => {
+    // `# SAM` is a section however much its text looks like a cue.
+    const nodes = parse('Sam waits.\n\n# SAM\n\nHe waits some more.\n');
+    expect(types(nodes)).toEqual(['action', 'section', 'action']);
+  });
+});
+
+describe('parseFountain — synopses', () => {
+  it('files a synopsis on the scene heading above it', () => {
+    const nodes = parse('INT. HOUSE - DAY\n\n= Sam finally asks.\n\nSam waits.\n');
+    expect(types(nodes)).toEqual(['sceneHeading', 'action']);
+    expect(nodes[0].attrs?.synopsis).toBe('Sam finally asks.');
+  });
+
+  it('files a synopsis on a section', () => {
+    const nodes = parse('# ACT ONE\n\n= Everything goes wrong.\n');
+    expect(types(nodes)).toEqual(['section']);
+    expect(nodes[0].attrs?.synopsis).toBe('Everything goes wrong.');
+  });
+
+  it('reaches back past other elements, since the spec allows one anywhere', () => {
+    const nodes = parse('INT. HOUSE - DAY\n\nSam waits.\n\n= He is still waiting.\n');
+    expect(types(nodes)).toEqual(['sceneHeading', 'action']);
+    expect(nodes[0].attrs?.synopsis).toBe('He is still waiting.');
+  });
+
+  it('keeps several synopsis lines under one heading', () => {
+    const nodes = parse('INT. HOUSE - DAY\n\n= One.\n= Two.\n');
+    expect(nodes[0].attrs?.synopsis).toBe('One.\nTwo.');
+  });
+
+  it('keeps a synopsis with nothing above it off the page as a note', () => {
+    const nodes = parse('= Nothing to file this on.\n\nSam waits.\n');
+    expect(types(nodes)).toEqual(['note', 'action']);
+  });
+
+  it('still reads === as a page break, not a synopsis', () => {
+    const nodes = parse('Before.\n\n===\n\nAfter.\n');
+    expect(types(nodes)).toEqual(['action', 'action']);
+    expect(nodes[1].attrs?.startsNewPage).toBe(true);
+  });
+
+  it('leaves == as Action', () => {
+    const nodes = parse('Sam waits.\n\n== not a synopsis\n');
+    expect(types(nodes)).toEqual(['action', 'action']);
+  });
+});
+
+describe('parseFountain — notes', () => {
+  it('lifts a standalone note out as its own non-printing block', () => {
+    const nodes = parse('Sam waits.\n\n[[ check the timeline ]]\n\nHe leaves.\n');
+    expect(types(nodes)).toEqual(['action', 'note', 'action']);
+    expect(textOf(nodes[1])).toBe('check the timeline');
+  });
+
+  it('takes an inline note out of the line it sat in', () => {
+    const nodes = parse('Sam waits [[ how long? ]] by the door.\n');
+    expect(types(nodes)).toEqual(['action', 'note']);
+    expect(textOf(nodes[0])).toBe('Sam waits  by the door.');
+    expect(textOf(nodes[1])).toBe('how long?');
+  });
+
+  it('folds a note that runs over several lines', () => {
+    const nodes = parse('Sam waits.\n\n[[ this note\nruns on ]]\n\nHe leaves.\n');
+    expect(types(nodes)).toEqual(['action', 'note', 'action']);
+    expect(textOf(nodes[1])).toBe('this note runs on');
+  });
+
+  it('does not let a note between a cue and its dialogue break the block', () => {
+    // The note's line is removed rather than blanked: a blank line here would
+    // end the dialogue block and drop the speech out as Action.
+    const nodes = parse('Sam waits.\n\nSAM\n[[ shouted? ]]\nGet out.\n');
+    expect(types(nodes)).toEqual(['action', 'character', 'dialogue', 'note']);
+    expect(textOf(nodes[2])).toBe('Get out.');
+  });
+});
+
+describe('parseFountain — boneyard', () => {
+  it('removes a commented-out block', () => {
+    const nodes = parse('Sam waits.\n\n/*\nHe does not leave.\n*/\n\nHe leaves.\n');
+    expect(types(nodes)).toEqual(['action', 'action']);
+    expect(textOf(nodes[1])).toBe('He leaves.');
+  });
+
+  it('does not weld the lines either side of a multi-line boneyard', () => {
+    const nodes = parse('INT. HOUSE - DAY\n/* cut this\nand this */\nSam waits.\n');
+    expect(types(nodes)).toEqual(['sceneHeading', 'action']);
+    expect(textOf(nodes[1])).toBe('Sam waits.');
+  });
+
+  it('removes a boneyard inside a line', () => {
+    const [node] = parse('Sam waits /* for now */ by the door.\n');
+    expect(textOf(node)).toBe('Sam waits  by the door.');
+  });
+
+  it('leaves an unterminated marker as literal text', () => {
+    const [node] = parse('Sam does 3 /* 4 in his head.\n');
+    expect(textOf(node)).toContain('/*');
+  });
+});
+
+describe('parseFountain — dialogue continuation', () => {
+  it('keeps a block alive across the two-space intentional blank line', () => {
+    // This is exactly what exportFountain writes for a paragraph break inside
+    // dialogue, so without it a `.fountain` saved by OpenDraft and reopened lost
+    // every line of a speech after its first break.
+    const nodes = parse('SAM\nOne.\n  \nTwo.\n');
+    expect(types(nodes)).toEqual(['character', 'dialogue', 'dialogue', 'dialogue']);
+    expect(textOf(nodes[3])).toBe('Two.');
+  });
+
+  it('still ends the block at a genuinely blank line', () => {
+    const nodes = parse('SAM\nOne.\n\nSam leaves.\n');
+    expect(types(nodes)).toEqual(['character', 'dialogue', 'action']);
+  });
+});
+
+describe('exportFountain — non-printing structure', () => {
+  it('writes a section with its hashes', () => {
+    const out = exportFountain(doc({ ...block('section', 'ACT ONE'), attrs: { level: 1 } }));
+    expect(out).toContain('# ACT ONE');
+  });
+
+  it('writes the depth a nested section carries', () => {
+    const out = exportFountain(doc({ ...block('section', 'Sequence A'), attrs: { level: 3 } }));
+    expect(out).toContain('### Sequence A');
+  });
+
+  it('writes a note in double brackets', () => {
+    const out = exportFountain(doc(block('note', 'check this')));
+    expect(out).toContain('[[check this]]');
+  });
+
+  it('writes each synopsis line with its own = sign', () => {
+    const out = exportFountain(
+      doc({ ...block('sceneHeading', 'INT. HOUSE - DAY'), attrs: { synopsis: 'One.\nTwo.' } }),
+    );
+    expect(out).toContain('= One.\n= Two.');
+  });
+
+  it('forces an Action line that opens with a hash', () => {
+    const out = exportFountain(doc(block('action', '#1 on the call sheet.')));
+    expect(out).toContain('!#1 on the call sheet.');
+  });
+
+  it('forces an Action line carrying a note marker', () => {
+    expect(exportFountain(doc(block('action', 'He said [[sic]].')))).toContain('!He said [[sic]].');
+  });
+
+  it('needs no force for a boneyard marker — the asterisk is already escaped', () => {
+    const out = exportFountain(doc(block('action', 'A 2/*3 split.')));
+    expect(out).toContain('A 2/\\*3 split.');
+    expect(out).not.toContain('/*');
+  });
+});
+
+describe('Fountain round trip: structure', () => {
+  const roundTrip = (d: JSONContent) => parseFountain(exportFountain(d)).content as Node[];
+
+  it('keeps a section a section, at its level', () => {
+    const out = roundTrip(doc(
+      { ...block('section', 'ACT ONE'), attrs: { level: 1 } },
+      { ...block('section', 'Sequence A'), attrs: { level: 2 } },
+      block('sceneHeading', 'INT. HOUSE - DAY'),
+      block('action', 'Sam waits.'),
+    ));
+    expect(types(out)).toEqual(['section', 'section', 'sceneHeading', 'action']);
+    expect(out.map((n) => n.attrs?.level)).toEqual([1, 2, undefined, undefined]);
+  });
+
+  it('keeps a note a note', () => {
+    const out = roundTrip(doc(block('action', 'Sam waits.'), block('note', 'check this')));
+    expect(types(out)).toEqual(['action', 'note']);
+    expect(textOf(out[1])).toBe('check this');
+  });
+
+  it('keeps a scene synopsis on its heading', () => {
+    const out = roundTrip(doc(
+      { ...block('sceneHeading', 'INT. HOUSE - DAY'), attrs: { synopsis: 'Sam asks.' } },
+      block('action', 'Sam waits.'),
+    ));
+    expect(out[0].attrs?.synopsis).toBe('Sam asks.');
+  });
+
+  it('keeps centred Action centred', () => {
+    const out = roundTrip(doc({ ...block('action', 'THE END'), attrs: { textAlign: 'center' } }));
+    expect(types(out)).toEqual(['action']);
+    expect(out[0].attrs?.textAlign).toBe('center');
+    expect(textOf(out[0])).toBe('THE END');
+  });
+
+  it('keeps an Action line that opens with a hash out of the outline', () => {
+    const out = roundTrip(doc(block('action', '#1 on the call sheet.')));
+    expect(types(out)).toEqual(['action']);
+    expect(textOf(out[0])).toBe('#1 on the call sheet.');
+  });
+
+  it('keeps a speech that spans several dialogue blocks together', () => {
+    // The Fountain parser makes one dialogue node per line, so a speech read in
+    // and written back out is several nodes. A blank line between them would
+    // end the block and drop everything after the first line to Action.
+    const out = roundTrip(doc(
+      block('character', 'SAM'),
+      block('dialogue', 'One.'),
+      block('dialogue', 'Two.'),
+    ));
+    expect(types(out)).toEqual(['character', 'dialogue', 'dialogue']);
+    expect(textOf(out[2])).toBe('Two.');
+  });
+
+  it('does not lose the rest of a speech after a paragraph break', () => {
+    const out = roundTrip(doc(
+      block('character', 'SAM'),
+      block('dialogue', 'One.'),
+      block('dialogue', ''),
+      block('dialogue', 'Two.'),
+    ));
+    expect(types(out)).toEqual(['character', 'dialogue', 'dialogue', 'dialogue']);
+    expect(textOf(out[3])).toBe('Two.');
+  });
+});
+
+describe('computeScriptStructure — section outline', () => {
+  it('nests sections by their level', () => {
+    const structure = computeScriptStructure(doc(
+      { ...block('section', 'ACT ONE'), attrs: { level: 1 } },
+      { ...block('section', 'Sequence A'), attrs: { level: 2 } },
+      { ...block('section', 'ACT TWO'), attrs: { level: 1 } },
+    ));
+    expect(structure.totalSections).toBe(3);
+    expect(structure.sections.map((s) => s.title)).toEqual(['ACT ONE', 'ACT TWO']);
+    expect(structure.sections[0].children.map((s) => s.title)).toEqual(['Sequence A']);
+  });
+
+  it('holds an outline that skips a level', () => {
+    const structure = computeScriptStructure(doc(
+      { ...block('section', 'Top'), attrs: { level: 1 } },
+      { ...block('section', 'Deep'), attrs: { level: 3 } },
+    ));
+    expect(structure.sections).toHaveLength(1);
+    expect(structure.sections[0].children.map((s) => s.level)).toEqual([3]);
+  });
+
+  it('files each scene under the section it sits below', () => {
+    const structure = computeScriptStructure(doc(
+      { ...block('section', 'ACT ONE'), attrs: { level: 1 } },
+      block('sceneHeading', 'INT. HOUSE - DAY'),
+      { ...block('section', 'ACT TWO'), attrs: { level: 1 } },
+      block('sceneHeading', 'EXT. STREET - NIGHT'),
+    ));
+    expect(structure.sections[0].scenes.map((s) => s.heading)).toEqual(['INT. HOUSE - DAY']);
+    expect(structure.sections[1].scenes.map((s) => s.heading)).toEqual(['EXT. STREET - NIGHT']);
+  });
+
+  it('leaves acts alone — a section is not an act break', () => {
+    const structure = computeScriptStructure(doc(
+      { ...block('section', 'ACT ONE'), attrs: { level: 1 } },
+      block('sceneHeading', 'INT. HOUSE - DAY'),
+    ));
+    expect(structure.acts.filter((a) => a.actNumber > 0)).toHaveLength(0);
+  });
+
+  it('reports no outline for a script without sections', () => {
+    const structure = computeScriptStructure(doc(block('sceneHeading', 'INT. HOUSE - DAY')));
+    expect(structure.sections).toEqual([]);
+    expect(structure.totalSections).toBe(0);
+  });
+});

--- a/frontend/src/utils/nonPrinting.ts
+++ b/frontend/src/utils/nonPrinting.ts
@@ -1,0 +1,18 @@
+/**
+ * Elements that live in the document but never reach the page.
+ *
+ * Fountain has two of them — Sections (`#`) and Notes (`[[ ]]`) — and the spec
+ * is explicit that neither is printed: they are there to outline and annotate
+ * the script from inside the script. Everything that measures or renders the
+ * finished page has to agree on that, or the writer sees one page count on
+ * screen and gets another in the PDF.
+ *
+ * One list, imported by pagination, the PDF/DOCX/FDX/OSF exporters and the
+ * print stylesheet's counterpart in the editor, so the four cannot drift.
+ */
+export const NON_PRINTING_TYPES: ReadonlySet<string> = new Set(['section', 'note']);
+
+/** Is this node type structural — kept in the file, kept off the page? */
+export function isNonPrintingType(type: string | undefined | null): boolean {
+  return !!type && NON_PRINTING_TYPES.has(type);
+}

--- a/frontend/src/utils/osfExporter.ts
+++ b/frontend/src/utils/osfExporter.ts
@@ -21,6 +21,7 @@ import JSZip from 'jszip';
 import type { JSONContent } from '@tiptap/react';
 import { sanitizeExportFilename } from './exportFilename';
 import { titlePageAttrsCarryData } from './titlePageRegion';
+import { isNonPrintingType } from './nonPrinting';
 
 /** Element type → the OSF style a paragraph is based on. */
 const NODE_TO_OSF_STYLE: Record<string, string> = {
@@ -306,6 +307,9 @@ export function exportOSF(doc: JSONContent, options: OSFExportOptions = {}): str
   let titlePageNode: JSONContent | null = null;
   const body: string[] = [];
   for (const node of doc.content ?? []) {
+    // Sections and Notes are not printed, and OSF has no paragraph style that
+    // isn't — see utils/nonPrinting.ts.
+    if (isNonPrintingType(node.type)) continue;
     if (node.type === 'titlePage') {
       if (!titlePageNode && titlePageAttrsCarryData(node.attrs as Record<string, unknown> | undefined)) {
         titlePageNode = node;

--- a/frontend/src/utils/pdfExporter.ts
+++ b/frontend/src/utils/pdfExporter.ts
@@ -17,6 +17,7 @@ import {
 } from './pdfUnicodeFont';
 import { embedCustomFonts, type EmbeddedFace } from './pdfCustomFonts';
 import { genericFor } from './fonts';
+import { isNonPrintingType } from './nonPrinting';
 
 // --- Constants matching pagination.ts ---
 
@@ -353,6 +354,12 @@ export async function exportPDF(doc: JSONContent, title: string, layout: PageLay
 
   docNodes.forEach((node, index) => {
     const typeName = node.type || 'general';
+
+    // Fountain's Sections and Notes are outline, not script. The spec is
+    // explicit that they stay in the file and off the printed page, and
+    // pagination already counts them as nothing — so the PDF must not draw
+    // them, or the file would run longer than the page count on screen.
+    if (isNonPrintingType(typeName)) return;
 
     if (hasTitlePage && index < region.length) {
       if (typeName === 'screenplayImage') {

--- a/frontend/src/utils/scriptStatistics.ts
+++ b/frontend/src/utils/scriptStatistics.ts
@@ -5,6 +5,7 @@
 import type { JSONContent } from '@tiptap/react';
 import { jsonBlockText, singleLine } from './nodeText';
 import type { CharacterProfile } from '../stores/editorStore';
+import { isNonPrintingType } from './nonPrinting';
 
 // ── Scene heading parsing (matching SceneNavigator patterns) ──────────
 
@@ -133,6 +134,9 @@ function extractSceneData(doc: JSONContent): SceneData[] {
   for (const node of doc.content) {
     const type = node.type || '';
     if (type === 'titlePage') continue;
+    // Outline and annotation, not script — counting a Section's words in the
+    // scene's word count would inflate a statistic meant to describe the page.
+    if (isNonPrintingType(type)) continue;
 
     const text = getTextContent(node);
     const words = countWords(text);

--- a/frontend/src/utils/scriptStructure.ts
+++ b/frontend/src/utils/scriptStructure.ts
@@ -33,8 +33,33 @@ export interface StructureAct {
   scenes: StructureScene[];
 }
 
+/**
+ * A Fountain Section (`#`, `##`, …) as a node of the outline tree.
+ *
+ * Sections are a hierarchy of their own, running alongside acts rather than
+ * inside them: a writer can outline in Sections without ever inserting an Act
+ * Break, and can do both at once. They are also never printed, which is what
+ * separates them from `newAct` — see utils/nonPrinting.ts.
+ */
+export interface StructureSection {
+  /** 1-based depth: the number of hashes the Section was written with. */
+  level: number;
+  title: string;
+  /** The `=` synopsis lines filed under this Section, if any. */
+  synopsis: string;
+  /** 0-based index among all `section` nodes, for navigating to it. */
+  sectionIndex: number;
+  /** Scenes under this Section, before the next Section at its level or above. */
+  scenes: StructureScene[];
+  children: StructureSection[];
+}
+
 export interface ScriptStructure {
   acts: StructureAct[];
+  /** The Section outline, nested by level. Empty when the script has none. */
+  sections: StructureSection[];
+  /** Total number of Sections at every level — what the outline header counts. */
+  totalSections: number;
   /** Map of sceneIndex → actNumber (null if no acts exist yet). */
   sceneActMap: Map<number, number | null>;
   /** Flat count of scene-heading nodes in the document. */
@@ -93,6 +118,14 @@ export function computeScriptStructure(doc: JSONContent): ScriptStructure {
     });
   };
 
+  // The Section outline. `openSections` is the chain of Sections currently in
+  // scope, deepest last — a new Section closes every open one at its level or
+  // deeper, and a Fountain file is free to jump from `#` straight to `###`, so
+  // the chain is trimmed by level rather than by counting rungs.
+  const sections: StructureSection[] = [];
+  const openSections: StructureSection[] = [];
+  let sectionIndex = 0;
+
   let currentAct: StructureAct | null = null;
   let sceneIndex = 0;
   let blockPos = 0;  // approximate TipTap pos — 1 for opening of each block, + size
@@ -118,6 +151,26 @@ export function computeScriptStructure(doc: JSONContent): ScriptStructure {
         scenes: [],
       };
       acts.push(currentAct);
+      blockPos += 2;
+      continue;
+    }
+
+    if (node.type === 'section') {
+      const level = Math.max(1, Number(node.attrs?.level) || 1);
+      const entry: StructureSection = {
+        level,
+        title: singleLine(getText(node)),
+        synopsis: (node.attrs?.synopsis as string | undefined) || '',
+        sectionIndex: sectionIndex++,
+        scenes: [],
+        children: [],
+      };
+      while (openSections.length > 0 && openSections[openSections.length - 1].level >= level) {
+        openSections.pop();
+      }
+      if (openSections.length === 0) sections.push(entry);
+      else openSections[openSections.length - 1].children.push(entry);
+      openSections.push(entry);
       blockPos += 2;
       continue;
     }
@@ -150,6 +203,8 @@ export function computeScriptStructure(doc: JSONContent): ScriptStructure {
       }
       targetAct.scenes.push(scene);
       sceneActMap.set(sceneIndex, targetAct.actNumber > 0 ? targetAct.actNumber : null);
+      // A scene belongs to the deepest Section still open above it.
+      if (openSections.length > 0) openSections[openSections.length - 1].scenes.push(scene);
 
       // Attach to sequence if applicable
       if (sequenceId) {
@@ -180,6 +235,8 @@ export function computeScriptStructure(doc: JSONContent): ScriptStructure {
 
   return {
     acts,
+    sections,
+    totalSections: sectionIndex,
     sceneActMap,
     totalScenes: sceneIndex,
   };

--- a/frontend/src/utils/scriptTiming.ts
+++ b/frontend/src/utils/scriptTiming.ts
@@ -28,6 +28,9 @@ const ELEMENT_RATES: Record<string, number> = {
   showEpisode: 0,
   titlePage: 0,
   sceneHeading: 0,
+  // Non-printing: nothing on the page, so nothing on the clock.
+  section: 0,
+  note: 0,
 };
 
 /** Fixed time for transition elements (seconds) */

--- a/frontend/src/utils/templateConflicts.ts
+++ b/frontend/src/utils/templateConflicts.ts
@@ -46,6 +46,9 @@ const DEFAULT_REPLACEMENTS: Record<string, string> = {
   showEpisode: 'general',
   newAct: 'sceneHeading',
   endOfAct: 'action',
+  // A section is outline, not script — demoting it to Action would print it.
+  section: 'note',
+  note: 'action',
 };
 
 export function getDefaultReplacement(elementType: string): string {

--- a/user-manual/import-export.html
+++ b/user-manual/import-export.html
@@ -111,6 +111,14 @@
     <h3 id="import-fountain">Fountain (.fountain)</h3>
     <p>Import scripts written in Fountain format. Fountain is an open, plain-text markup language for screenwriting. Many free tools can create Fountain files. Emphasis markup (<code>*italic*</code>, <code>**bold**</code>, <code>_underline_</code>), forced elements (<code>!</code>, <code>~</code>, <code>.</code>, <code>&gt;</code>, <code>@</code>), centred text (<code>&gt;text&lt;</code>) and page breaks (<code>===</code>) are all recognised.</p>
 
+    <p>Fountain&rsquo;s outlining markup comes through as well, and stays off the printed page:</p>
+    <ul>
+      <li><strong>Sections</strong> (<code>#</code>, <code>##</code>, <code>###</code>&hellip;) become Section elements, nested to the depth their hashes describe, and appear in the Scene Navigator&rsquo;s <strong>Structure</strong> tab. They are kept separate from New Act and End of Act, which are act markers that <em>do</em> print.</li>
+      <li><strong>Synopses</strong> (<code>= &hellip;</code>) are filed on the scene heading or Section they sit under.</li>
+      <li><strong>Notes</strong> (<code>[[ &hellip; ]]</code>) become Note elements, whether they stand alone or sit inside a line.</li>
+      <li>The <strong>boneyard</strong> (<code>/*&nbsp;&hellip;&nbsp;*/</code>) is commented-out text, and is dropped.</li>
+    </ul>
+
     <h3 id="import-fadein">Fade In (.fadein) and Open Screenplay Format (.osf)</h3>
     <p>Open scripts saved by <a href="https://www.fadeinpro.com/" target="_blank" rel="noopener">Fade In</a> directly &mdash; there is no need to export to another format first. A <code>.fadein</code> file is a compressed Open Screenplay Format document, and OpenDraft reads both it and plain <code>.osf</code> files. Imported:</p>
     <ul>

--- a/user-manual/writing-screenplay.html
+++ b/user-manual/writing-screenplay.html
@@ -185,6 +185,38 @@
       <li><strong>Cast List</strong> &mdash; Lists of cast members.</li>
     </ul>
 
+    <h3 id="outline-elements">Outline Elements (Not Printed)</h3>
+
+    <p>
+      Two elements exist to organise the script rather than to appear in it. Neither is included
+      when you print or export to PDF, Word, Final Draft or Open Screenplay Format, and neither
+      counts towards the page count or the script statistics.
+    </p>
+
+    <ul>
+      <li>
+        <strong>Section</strong> &mdash; An outline heading. Sections nest: the Scene Navigator's
+        <strong>Structure</strong> tab shows them as a tree with the scenes filed under each one.
+        In a Fountain file a Section is a line beginning with one or more hashes
+        (<code>#&nbsp;ACT ONE</code>, <code>##&nbsp;Sequence One</code>), and the number of hashes
+        is its depth. Use a Section for structure you want to navigate by; use
+        <strong>New Act</strong> for an act break the reader is meant to see on the page.
+      </li>
+      <li>
+        <strong>Note</strong> &mdash; An aside to yourself, kept in the file and left off the page.
+        This is Fountain's <code>[[&nbsp;double bracket&nbsp;]]</code> note. For notes anchored to a
+        particular run of text, with colours and a panel of their own, use
+        <a href="script-notes.html">Script Notes</a> instead.
+      </li>
+    </ul>
+
+    <p>
+      A <strong>Synopsis</strong> is a third piece of outline that is not printed. It is not an
+      element of its own &mdash; it belongs to a scene heading or a Section, and is written in
+      Fountain as a line beginning with <code>=</code>. Scene synopses are shown and edited from the
+      Scene Navigator.
+    </p>
+
     <h2 id="switching-elements">Switching Element Types</h2>
 
     <p>There are three ways to change the element type of the current line:</p>


### PR DESCRIPTION
Issue #82 was reopened against Sections: `# ACT ONE` came into the script
as a line of Action and printed on the page. It was not alone — none of
the four things Fountain keeps out of the printed script were
implemented, and each arrived as Action:

  - Sections (`#`, `##`, …) — the outline
  - Synopses (`=`) — read only directly under a scene heading
  - Notes (`[[ … ]]`) — brackets and all, mid-scene
  - The boneyard (`/* … */`) — commented-out text, uncommented

Sections and Notes are now elements of their own, and "non-printing" is
one list (utils/nonPrinting.ts) that pagination, the PDF, DOCX, FDX and
OSF exporters, the print stylesheet, the page-length and script
statistics all read. A Section carries the depth its hashes describe, so
the hierarchy survives, and the Scene Navigator's Structure tab draws it
as a tree with each scene filed under the Section above it — alongside
acts rather than inside them, because New Act and End of Act are act
markers a reader is meant to see and a Section is not.

A synopsis is filed on the nearest scene heading or Section above it,
since the spec allows one anywhere. The boneyard is removed, keeping the
newlines it spanned so it cannot weld the lines either side together.
Notes are lifted out of the line they sat in; a line that held nothing
but a note is removed rather than blanked, or the blank line left behind
would have cut a dialogue block in two.

Three more round-trip faults turned up while testing this, all of them
silent corruption of a `.fountain` saved and reopened:

  - A blank line was written after every Dialogue node. A speech read in
    from Fountain is one node per line, so saving and reopening dropped
    every line of a speech after the first to Action. The blank line is
    now written only where the block actually ends.
  - The spec's two-space "this blank line is intentional" — which the
    exporter already wrote — was not read back, so a paragraph break
    inside dialogue ended the block.
  - Centred Action was written as ordinary Action and came back flush
    left. It is `>text<` now.

Action that would be re-read as a Section or a note is forced with `!`.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LKCBS297MvngvwG7X4Wurp