### PR TITLE
Keep the Android navigator out of the status bar, and let About use the screen

### DIFF
--- a/frontend/src/styles/screenplay.css
+++ b/frontend/src/styles/screenplay.css
@@ -2864,6 +2864,32 @@ div[data-type="cast-list"].is-empty::before { content: 'Cast...'; color: #ccc; p
   min-width: 440px;
   max-width: 500px;
 }
+
+/* Phones and tablets: full bleed, for the reasons the manual is — a 500px card
+   with the =<480px sheet rules capping it at 60vh leaves About and Diagnostics
+   scrolling a sliver of themselves on a device that has the room. Same shape as
+   the manual's rule: both classes so it outranks that cap, `position: fixed` so
+   the overlay's padding cannot push its footer off the bottom, and the safe-area
+   insets the fixed position gives up. */
+@media (max-width: 1024px), (pointer: coarse) and (max-height: 900px) {
+  .dialog-box.about-dialog {
+    position: fixed; top: 0; left: 0;
+    width: 100vw; min-width: 0; max-width: none;
+    height: var(--vv-height, 100dvh); max-height: var(--vv-height, 100dvh);
+    border-radius: 0; border: none;
+    padding-top: env(safe-area-inset-top, 0px);
+    padding-bottom: env(safe-area-inset-bottom, 0px);
+    /* Scrolling belongs to the body, so the header and the buttons stay put. */
+    overflow: hidden;
+  }
+  /* Android under-reports the inset (see the note by .app-container), and a
+     fixed box has no container padding to fall back on. */
+  html.android .dialog-box.about-dialog,
+  html.android .dialog-box.manual-dialog {
+    padding-top: max(env(safe-area-inset-top, 0px), 28px);
+    padding-bottom: max(env(safe-area-inset-bottom, 0px), 24px);
+  }
+}
 .about-body {
   text-align: center;
 }
@@ -9891,6 +9917,18 @@ body.pencil-caret-active .page .ProseMirror { caret-color: transparent; }
   html.android .tags-panel,
   html.android .location-db-panel {
     padding-top: max(env(safe-area-inset-top), 28px);
+  }
+
+  /* The scene navigator is the same story on the other side, and was missed:
+     as an overlay drawer its tab row landed in the status bar, which put the
+     tabs and the close button behind the system bar where taps never reached
+     them. Scoped to the breakpoint where it is an overlay — docked, it sits
+     below the menu bar inside the container's padding and wants none of this.
+     iOS has the matching rule further down. */
+  @media (max-width: 1100px) {
+    html.android .scene-navigator {
+      padding-top: max(env(safe-area-inset-top), 28px);
+    }
   }
 
   /* iOS/iPadOS: the insets above only started reporting real values once


### PR DESCRIPTION
## What does this PR do?

Two mobile-chrome bugs found while testing #99 on an Android emulator and the iOS simulators. Both are in `screenplay.css` and nowhere else.

**The scene navigator was unusable as a drawer on Android.** Below 900px it is `position: fixed` at `top: 0`, which takes it outside `.app-container` and out of the padding that keeps content clear of the system bars. Its tab row and close button rendered *behind* the status bar — the clock showed through "SCENES" — so tapping a tab or the ✕ did nothing at all. The right-hand slide-overs already had an Android clearance rule and the navigator had been left out of it; it now takes the same `max(env(safe-area-inset-top), 28px)`, scoped to the breakpoint where it is an overlay so a docked navigator is not padded twice. iOS has had the matching rule since #96, which is why this only showed on Android.

**About and Diagnostics opened as a 500px card capped at 60vh.** The `≤480px` `.dialog-box` sheet rules cap every dialog at 60vh — right for a two-field dialog, wrong for a screen the user is meant to read. They now go full bleed on phones and tablets, the same treatment the user manual got in #99 and written the same way: both classes so it outranks that cap, `position: fixed` so the overlay's padding cannot push the buttons off the bottom, and the safe-area insets a fixed box gives up. Android under-reports `env()`, so it takes the same 28px floor `.app-container` uses.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring (no functional change)
- [ ] Documentation
- [ ] Other (describe below)

## How was this tested?

**On an Android emulator (Pixel, Android 16), against a real build containing both rules.** The build was made by the session working on #98, which shared this checkout at the time; I inspected its screenshots rather than taking the result on trust.

- **View → Panels → Navigator** — the tab row (SCENES / PAGES / LOCATIONS / STRUCTURE) and the ✕ sit below the status bar with clear separation: the clock is above them. In the same view before the fix, the clock was visibly showing *through* "SCENES". Taps land now — tapping PAGES switched tab, tapping ✕ closed the drawer.
- **Help → About Open Draft** — full screen height: header at the top, the What's New body scrolling in the middle, Close pinned at the bottom above the gesture bar. It was a short card capped at 60vh before.

Not exercised on iOS. The About rule is not Android-scoped, so it applies there too and is the same shape as the manual's full-bleed rule that was verified on an iPad in #99; the navigator rule is `html.android`-only and cannot affect iOS, which has had its own since #96.

CSS-only, so the frontend typecheck and unit tests are unaffected — the session sharing the checkout reported both still green (915 tests) after these hunks were applied and removed.

## Screenshots (if applicable)

None attached — the before state is a drawer rendered behind the status bar, which is more useful as the reproduction step above than as a still.

## Checklist

- [x] I've read the [Contributing Guide](docs/CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I've tested my changes locally — on an Android emulator (see above)
- [x] I've updated documentation if needed — no user-facing behaviour to document beyond the fix itself

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LQwSexVvjtvqhHkpBaySDe
