### PR TITLE
Release v0.26.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,13 +149,13 @@ Get the latest version — no account required, just install and start writing. 
 
 | Platform | Download |
 |----------|----------|
-| **macOS** (Apple Silicon) | [Download .dmg](https://github.com/Proteus-Technologies-Private-Limited/OpenDraft/releases/latest/download/OpenDraft_0.26.1_aarch64.dmg) |
-| **macOS** (Intel) | [Download .dmg](https://github.com/Proteus-Technologies-Private-Limited/OpenDraft/releases/latest/download/OpenDraft_0.26.1_x64.dmg) |
-| **Windows** (64-bit) | [Download .exe](https://github.com/Proteus-Technologies-Private-Limited/OpenDraft/releases/latest/download/OpenDraft_0.26.1_x64-setup.exe) |
-| **Windows** (MSI) | [Download .msi](https://github.com/Proteus-Technologies-Private-Limited/OpenDraft/releases/latest/download/OpenDraft_0.26.1_x64_en-US.msi) |
-| **Linux** (Debian/Ubuntu) | [Download .deb](https://github.com/Proteus-Technologies-Private-Limited/OpenDraft/releases/latest/download/OpenDraft_0.26.1_amd64.deb) |
-| **Linux** (AppImage) | [Download .AppImage](https://github.com/Proteus-Technologies-Private-Limited/OpenDraft/releases/latest/download/OpenDraft_0.26.1_amd64.AppImage) |
-| **Linux** (RPM/Fedora) | [Download .rpm](https://github.com/Proteus-Technologies-Private-Limited/OpenDraft/releases/latest/download/OpenDraft-0.26.1-1.x86_64.rpm) |
+| **macOS** (Apple Silicon) | [Download .dmg](https://github.com/Proteus-Technologies-Private-Limited/OpenDraft/releases/latest/download/OpenDraft_0.26.2_aarch64.dmg) |
+| **macOS** (Intel) | [Download .dmg](https://github.com/Proteus-Technologies-Private-Limited/OpenDraft/releases/latest/download/OpenDraft_0.26.2_x64.dmg) |
+| **Windows** (64-bit) | [Download .exe](https://github.com/Proteus-Technologies-Private-Limited/OpenDraft/releases/latest/download/OpenDraft_0.26.2_x64-setup.exe) |
+| **Windows** (MSI) | [Download .msi](https://github.com/Proteus-Technologies-Private-Limited/OpenDraft/releases/latest/download/OpenDraft_0.26.2_x64_en-US.msi) |
+| **Linux** (Debian/Ubuntu) | [Download .deb](https://github.com/Proteus-Technologies-Private-Limited/OpenDraft/releases/latest/download/OpenDraft_0.26.2_amd64.deb) |
+| **Linux** (AppImage) | [Download .AppImage](https://github.com/Proteus-Technologies-Private-Limited/OpenDraft/releases/latest/download/OpenDraft_0.26.2_amd64.AppImage) |
+| **Linux** (RPM/Fedora) | [Download .rpm](https://github.com/Proteus-Technologies-Private-Limited/OpenDraft/releases/latest/download/OpenDraft-0.26.2-1.x86_64.rpm) |
 
 ### Mobile
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -46,7 +46,7 @@ async def lifespan(app: FastAPI):
 app = FastAPI(
     title="OpenDraft API",
     description="Backend API for OpenDraft screenwriting application",
-    version="0.26.1",
+    version="0.26.2",
     lifespan=lifespan,
 )
 

--- a/frontend/src/components/MenuBar.tsx
+++ b/frontend/src/components/MenuBar.tsx
@@ -2372,11 +2372,11 @@ const MenuBar: React.FC<MenuBarProps> = ({
           <div className="dialog-header">About Open Draft</div>
           <div className="dialog-body about-body">
             <div className="about-title">Open Draft</div>
-            <div className="about-version">Version 0.26.1</div>
+            <div className="about-version">Version 0.26.2</div>
             <div className="about-tagline">Free, open-source screenwriting software</div>
 
             <div className="about-whats-new">
-              <div className="about-section-title">What's New in 0.26.1</div>
+              <div className="about-section-title">What's New in 0.26.2</div>
               <div className="about-changelog">
               <div className="about-subsection-title">v0.26.2</div>
               <ul className="about-list">

--- a/frontend/src/services/diagnostics.ts
+++ b/frontend/src/services/diagnostics.ts
@@ -98,7 +98,7 @@ function getAppVersion(): string {
   if (typeof window !== 'undefined' && (window as any).__OPENDRAFT_VERSION__) {
     return (window as any).__OPENDRAFT_VERSION__;
   }
-  return '0.26.1';
+  return '0.26.2';
 }
 
 /** Format a report as plain text suitable for pasting into a GitHub issue. */

--- a/landing/index.html
+++ b/landing/index.html
@@ -801,17 +801,17 @@
         <p class="section-desc">Available on every major platform. Free, no account needed. Most users are writing in under 2 minutes.</p>
       </div>
       <div class="download-grid">
-        <a href="https://github.com/Proteus-Technologies-Private-Limited/OpenDraft/releases/latest/download/OpenDraft_0.26.1_aarch64.dmg" class="download-card">
+        <a href="https://github.com/Proteus-Technologies-Private-Limited/OpenDraft/releases/latest/download/OpenDraft_0.26.2_aarch64.dmg" class="download-card">
           <svg class="platform-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5"><rect x="2" y="3" width="20" height="14" rx="2"/><line x1="8" y1="21" x2="16" y2="21"/><line x1="12" y1="17" x2="12" y2="21"/></svg>
           <h3>macOS</h3>
           <p>Apple Silicon .dmg</p>
         </a>
-        <a href="https://github.com/Proteus-Technologies-Private-Limited/OpenDraft/releases/latest/download/OpenDraft_0.26.1_x64-setup.exe" class="download-card">
+        <a href="https://github.com/Proteus-Technologies-Private-Limited/OpenDraft/releases/latest/download/OpenDraft_0.26.2_x64-setup.exe" class="download-card">
           <svg class="platform-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5"><rect x="2" y="3" width="20" height="14" rx="2"/><line x1="8" y1="21" x2="16" y2="21"/><line x1="12" y1="17" x2="12" y2="21"/></svg>
           <h3>Windows</h3>
           <p>64-bit installer</p>
         </a>
-        <a href="https://github.com/Proteus-Technologies-Private-Limited/OpenDraft/releases/latest/download/OpenDraft_0.26.1_amd64.deb" class="download-card">
+        <a href="https://github.com/Proteus-Technologies-Private-Limited/OpenDraft/releases/latest/download/OpenDraft_0.26.2_amd64.deb" class="download-card">
           <svg class="platform-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5"><rect x="4" y="2" width="16" height="20" rx="2"/><line x1="12" y1="18" x2="12" y2="18.01"/></svg>
           <h3>Linux</h3>
           <p>.deb / .AppImage / .rpm</p>
@@ -823,27 +823,27 @@
           More download options
         </summary>
         <div class="download-grid" style="margin-top:16px;">
-          <a href="https://github.com/Proteus-Technologies-Private-Limited/OpenDraft/releases/latest/download/OpenDraft_0.26.1_x64.dmg" class="download-card">
+          <a href="https://github.com/Proteus-Technologies-Private-Limited/OpenDraft/releases/latest/download/OpenDraft_0.26.2_x64.dmg" class="download-card">
             <svg class="platform-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5"><rect x="2" y="3" width="20" height="14" rx="2"/><line x1="8" y1="21" x2="16" y2="21"/><line x1="12" y1="17" x2="12" y2="21"/></svg>
             <h3>macOS (Intel)</h3>
             <p>For Intel Macs running macOS 12 Monterey or newer</p>
           </a>
-          <a href="https://github.com/Proteus-Technologies-Private-Limited/OpenDraft/releases/latest/download/OpenDraft_0.26.1_x86_64-legacy.dmg" class="download-card">
+          <a href="https://github.com/Proteus-Technologies-Private-Limited/OpenDraft/releases/latest/download/OpenDraft_0.26.2_x86_64-legacy.dmg" class="download-card">
             <svg class="platform-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5"><rect x="2" y="3" width="20" height="14" rx="2"/><line x1="8" y1="21" x2="16" y2="21"/><line x1="12" y1="17" x2="12" y2="21"/></svg>
             <h3>macOS (Older Intel)</h3>
             <p>For Intel Macs running macOS 10.13 High Sierra through 11 Big Sur</p>
           </a>
-          <a href="https://github.com/Proteus-Technologies-Private-Limited/OpenDraft/releases/latest/download/OpenDraft_0.26.1_x64_en-US.msi" class="download-card">
+          <a href="https://github.com/Proteus-Technologies-Private-Limited/OpenDraft/releases/latest/download/OpenDraft_0.26.2_x64_en-US.msi" class="download-card">
             <svg class="platform-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5"><rect x="2" y="3" width="20" height="14" rx="2"/><line x1="8" y1="21" x2="16" y2="21"/><line x1="12" y1="17" x2="12" y2="21"/></svg>
             <h3>Windows (MSI)</h3>
             <p>64-bit MSI installer</p>
           </a>
-          <a href="https://github.com/Proteus-Technologies-Private-Limited/OpenDraft/releases/latest/download/OpenDraft_0.26.1_amd64.AppImage" class="download-card">
+          <a href="https://github.com/Proteus-Technologies-Private-Limited/OpenDraft/releases/latest/download/OpenDraft_0.26.2_amd64.AppImage" class="download-card">
             <svg class="platform-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5"><rect x="4" y="2" width="16" height="20" rx="2"/><line x1="12" y1="18" x2="12" y2="18.01"/></svg>
             <h3>Linux (AppImage)</h3>
             <p>Portable, no install needed</p>
           </a>
-          <a href="https://github.com/Proteus-Technologies-Private-Limited/OpenDraft/releases/latest/download/OpenDraft_0.26.1_android.apk" class="download-card">
+          <a href="https://github.com/Proteus-Technologies-Private-Limited/OpenDraft/releases/latest/download/OpenDraft_0.26.2_android.apk" class="download-card">
             <svg class="platform-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5"><rect x="5" y="2" width="14" height="20" rx="3"/><line x1="12" y1="18" x2="12" y2="18.01"/></svg>
             <h3>Android (APK)</h3>
             <p>Sideload .apk</p>

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2788,7 +2788,7 @@ dependencies = [
 
 [[package]]
 name = "opendraft"
-version = "0.26.1"
+version = "0.26.2"
 dependencies = [
  "jni",
  "percent-encoding",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "opendraft"
-version = "0.26.1"
+version = "0.26.2"
 description = "OpenDraft - Professional Screenwriting Application"
 authors = ["OpenDraft"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-config-schema/schema.json",
   "productName": "OpenDraft",
-  "version": "0.26.1",
+  "version": "0.26.2",
   "identifier": "com.proteus.opendraft",
   "build": {
     "frontendDist": "../frontend/dist",

--- a/user-manual/backups.html
+++ b/user-manual/backups.html
@@ -220,7 +220,7 @@
 
   </div>
   <footer class="footer">
-    OpenDraft User Manual &middot; v0.26.1 &middot; Made by Proteus Technologies
+    OpenDraft User Manual &middot; v0.26.2 &middot; Made by Proteus Technologies
   </footer>
 </main>
 

--- a/user-manual/beat-board.html
+++ b/user-manual/beat-board.html
@@ -178,7 +178,7 @@
 
   </div>
   <footer class="footer">
-    OpenDraft User Manual &middot; v0.26.1 &middot; Made by Proteus Technologies
+    OpenDraft User Manual &middot; v0.26.2 &middot; Made by Proteus Technologies
   </footer>
 </main>
 

--- a/user-manual/characters.html
+++ b/user-manual/characters.html
@@ -348,7 +348,7 @@
 
   </div>
   <footer class="footer">
-    OpenDraft User Manual &middot; v0.26.1 &middot; Made by Proteus Technologies
+    OpenDraft User Manual &middot; v0.26.2 &middot; Made by Proteus Technologies
   </footer>
 </main>
 

--- a/user-manual/collaboration.html
+++ b/user-manual/collaboration.html
@@ -245,7 +245,7 @@
 
   </div>
   <footer class="footer">
-    OpenDraft User Manual &middot; v0.26.1 &middot; Made by Proteus Technologies
+    OpenDraft User Manual &middot; v0.26.2 &middot; Made by Proteus Technologies
   </footer>
 </main>
 

--- a/user-manual/find-replace.html
+++ b/user-manual/find-replace.html
@@ -170,7 +170,7 @@
 
   </div>
   <footer class="footer">
-    OpenDraft User Manual &middot; v0.26.1 &middot; Made by Proteus Technologies
+    OpenDraft User Manual &middot; v0.26.2 &middot; Made by Proteus Technologies
   </footer>
 </main>
 

--- a/user-manual/format-compatibility.html
+++ b/user-manual/format-compatibility.html
@@ -293,7 +293,7 @@
 
   </div>
   <footer class="footer">
-    OpenDraft User Manual &middot; v0.26.1 &middot; Made by Proteus Technologies
+    OpenDraft User Manual &middot; v0.26.2 &middot; Made by Proteus Technologies
   </footer>
 </main>
 

--- a/user-manual/formatting.html
+++ b/user-manual/formatting.html
@@ -462,7 +462,7 @@
 
   </div>
   <footer class="footer">
-    OpenDraft User Manual &middot; v0.26.1 &middot; Made by Proteus Technologies
+    OpenDraft User Manual &middot; v0.26.2 &middot; Made by Proteus Technologies
   </footer>
 </main>
 

--- a/user-manual/getting-started.html
+++ b/user-manual/getting-started.html
@@ -268,7 +268,7 @@
 
   </div>
   <footer class="footer">
-    OpenDraft User Manual &middot; v0.26.1 &middot; Made by Proteus Technologies
+    OpenDraft User Manual &middot; v0.26.2 &middot; Made by Proteus Technologies
   </footer>
 </main>
 

--- a/user-manual/import-export.html
+++ b/user-manual/import-export.html
@@ -284,7 +284,7 @@
 
   </div>
   <footer class="footer">
-    OpenDraft User Manual &middot; v0.26.1 &middot; Made by Proteus Technologies
+    OpenDraft User Manual &middot; v0.26.2 &middot; Made by Proteus Technologies
   </footer>
 </main>
 

--- a/user-manual/index-cards.html
+++ b/user-manual/index-cards.html
@@ -159,7 +159,7 @@
 
   </div>
   <footer class="footer">
-    OpenDraft User Manual &middot; v0.26.1 &middot; Made by Proteus Technologies
+    OpenDraft User Manual &middot; v0.26.2 &middot; Made by Proteus Technologies
   </footer>
 </main>
 

--- a/user-manual/index.html
+++ b/user-manual/index.html
@@ -412,7 +412,7 @@
 
   </div>
   <footer class="footer">
-    OpenDraft User Manual &middot; v0.26.1 &middot; Made by Proteus Technologies
+    OpenDraft User Manual &middot; v0.26.2 &middot; Made by Proteus Technologies
   </footer>
 </main>
 

--- a/user-manual/installation.html
+++ b/user-manual/installation.html
@@ -236,7 +236,7 @@ pip install -r backend/requirements.txt</code></pre>
 
   </div>
   <footer class="footer">
-    OpenDraft User Manual &middot; v0.26.1 &middot; Made by Proteus Technologies
+    OpenDraft User Manual &middot; v0.26.2 &middot; Made by Proteus Technologies
   </footer>
 </main>
 

--- a/user-manual/keyboard-shortcuts.html
+++ b/user-manual/keyboard-shortcuts.html
@@ -181,7 +181,7 @@
 
   </div>
   <footer class="footer">
-    OpenDraft User Manual &middot; v0.26.1 &middot; Made by Proteus Technologies
+    OpenDraft User Manual &middot; v0.26.2 &middot; Made by Proteus Technologies
   </footer>
 </main>
 

--- a/user-manual/locations.html
+++ b/user-manual/locations.html
@@ -174,7 +174,7 @@ INT. COFFEE SHOP - DAY</code></pre>
 
   </div>
   <footer class="footer">
-    OpenDraft User Manual &middot; v0.26.1 &middot; Made by Proteus Technologies
+    OpenDraft User Manual &middot; v0.26.2 &middot; Made by Proteus Technologies
   </footer>
 </main>
 

--- a/user-manual/manifest.json
+++ b/user-manual/manifest.json
@@ -1,161 +1,161 @@
 {
-  "version": "809c8d02c25ef764",
+  "version": "2a95c4834764a9dc",
   "pages": [
     {
       "slug": "index.html",
       "title": "Home",
       "section": "Getting Started",
-      "hash": "fcfddfe8a516256e"
+      "hash": "b307926b923f98a0"
     },
     {
       "slug": "getting-started.html",
       "title": "Getting Started",
       "section": "Getting Started",
-      "hash": "52ac067ebe890ed3"
+      "hash": "38a0942d635fa1e0"
     },
     {
       "slug": "installation.html",
       "title": "Installation",
       "section": "Getting Started",
-      "hash": "e47e81258c3644a2"
+      "hash": "5101542705d9984f"
     },
     {
       "slug": "writing-screenplay.html",
       "title": "Writing Your Screenplay",
       "section": "Writing",
-      "hash": "d55b6c6f74121d48"
+      "hash": "c802f43cb2fd4b39"
     },
     {
       "slug": "formatting.html",
       "title": "Formatting",
       "section": "Writing",
-      "hash": "7da5ec1b22414ad3"
+      "hash": "fb16e9272bdbacb5"
     },
     {
       "slug": "title-page.html",
       "title": "Title Page",
       "section": "Writing",
-      "hash": "0d35b39111798a12"
+      "hash": "05dda22a6b977082"
     },
     {
       "slug": "find-replace.html",
       "title": "Find & Replace",
       "section": "Writing",
-      "hash": "649ada9b9a07c778"
+      "hash": "b8b1e39af4fd8907"
     },
     {
       "slug": "spell-check.html",
       "title": "Spell Check",
       "section": "Writing",
-      "hash": "f5bd884505ed937e"
+      "hash": "a2c4b2ae3700b972"
     },
     {
       "slug": "scene-navigator.html",
       "title": "Scene Navigator",
       "section": "Story Planning",
-      "hash": "48465110afa443aa"
+      "hash": "f3f89a4794ae6e12"
     },
     {
       "slug": "index-cards.html",
       "title": "Index Cards",
       "section": "Story Planning",
-      "hash": "b08e4dc20277214a"
+      "hash": "30dcb0cc45a112b1"
     },
     {
       "slug": "beat-board.html",
       "title": "Beat Board",
       "section": "Story Planning",
-      "hash": "c213fcad684895bd"
+      "hash": "bc88d48aa9c91118"
     },
     {
       "slug": "characters.html",
       "title": "Characters",
       "section": "Characters & Notes",
-      "hash": "d3cf5a44408c0988"
+      "hash": "f33c584b4a174995"
     },
     {
       "slug": "script-notes.html",
       "title": "Script Notes",
       "section": "Characters & Notes",
-      "hash": "ba4458c5cacb31fa"
+      "hash": "84b1c9fbaba1ce6b"
     },
     {
       "slug": "script-statistics.html",
       "title": "Script Statistics & Timing",
       "section": "Analysis",
-      "hash": "730ae60a0f67e864"
+      "hash": "abbb99ff093e130b"
     },
     {
       "slug": "tags.html",
       "title": "Tags & Entities",
       "section": "Production",
-      "hash": "5e3d7abd96e52498"
+      "hash": "c6e6778a7b8caa87"
     },
     {
       "slug": "locations.html",
       "title": "Locations",
       "section": "Production",
-      "hash": "3d0f17da08664fe2"
+      "hash": "f9d39e40c1fb4fa6"
     },
     {
       "slug": "revision-mode.html",
       "title": "Revision Mode",
       "section": "Production",
-      "hash": "543613abd1abeeb8"
+      "hash": "34791364463c2e0a"
     },
     {
       "slug": "projects.html",
       "title": "Managing Projects",
       "section": "Projects & Files",
-      "hash": "a3e31ea3a101dcbe"
+      "hash": "1d978f1b9282f5df"
     },
     {
       "slug": "version-history.html",
       "title": "Version History",
       "section": "Projects & Files",
-      "hash": "ea774bdc1296f3b4"
+      "hash": "096c14ccbd50873e"
     },
     {
       "slug": "backups.html",
       "title": "Backups & Recovery",
       "section": "Projects & Files",
-      "hash": "2b10c7e4dcf33a58"
+      "hash": "f3cf82646569c96e"
     },
     {
       "slug": "import-export.html",
       "title": "Import & Export",
       "section": "Projects & Files",
-      "hash": "307fffff6cb4df2f"
+      "hash": "5de7a04f89f9a0a2"
     },
     {
       "slug": "format-compatibility.html",
       "title": "Format Compatibility",
       "section": "Projects & Files",
-      "hash": "fd3365041938788f"
+      "hash": "b2b4f92ecdca08d4"
     },
     {
       "slug": "collaboration.html",
       "title": "Real-Time Collaboration",
       "section": "Collaboration",
-      "hash": "75bcc11e44c928af"
+      "hash": "27eb7ae4ca0e90f8"
     },
     {
       "slug": "themes.html",
       "title": "Themes",
       "section": "Customization",
-      "hash": "01f73580d411b062"
+      "hash": "adc17ce096272698"
     },
     {
       "slug": "page-setup.html",
       "title": "Page Setup",
       "section": "Customization",
-      "hash": "254a6e6a4644b995"
+      "hash": "c5a2787800e63e50"
     },
     {
       "slug": "keyboard-shortcuts.html",
       "title": "Keyboard Shortcuts",
       "section": "Customization",
-      "hash": "b9dfb0b47ce33bd2"
+      "hash": "b867f7ad94e165dc"
     }
   ]
 }

--- a/user-manual/page-setup.html
+++ b/user-manual/page-setup.html
@@ -216,7 +216,7 @@
 
   </div>
   <footer class="footer">
-    OpenDraft User Manual &middot; v0.26.1 &middot; Made by Proteus Technologies
+    OpenDraft User Manual &middot; v0.26.2 &middot; Made by Proteus Technologies
   </footer>
 </main>
 

--- a/user-manual/projects.html
+++ b/user-manual/projects.html
@@ -263,7 +263,7 @@
 
   </div>
   <footer class="footer">
-    OpenDraft User Manual &middot; v0.26.1 &middot; Made by Proteus Technologies
+    OpenDraft User Manual &middot; v0.26.2 &middot; Made by Proteus Technologies
   </footer>
 </main>
 

--- a/user-manual/revision-mode.html
+++ b/user-manual/revision-mode.html
@@ -169,7 +169,7 @@
 
   </div>
   <footer class="footer">
-    OpenDraft User Manual &middot; v0.26.1 &middot; Made by Proteus Technologies
+    OpenDraft User Manual &middot; v0.26.2 &middot; Made by Proteus Technologies
   </footer>
 </main>
 

--- a/user-manual/scene-navigator.html
+++ b/user-manual/scene-navigator.html
@@ -167,7 +167,7 @@
 
   </div>
   <footer class="footer">
-    OpenDraft User Manual &middot; v0.26.1 &middot; Made by Proteus Technologies
+    OpenDraft User Manual &middot; v0.26.2 &middot; Made by Proteus Technologies
   </footer>
 </main>
 

--- a/user-manual/script-notes.html
+++ b/user-manual/script-notes.html
@@ -261,7 +261,7 @@
 
   </div>
   <footer class="footer">
-    OpenDraft User Manual &middot; v0.26.1 &middot; Made by Proteus Technologies
+    OpenDraft User Manual &middot; v0.26.2 &middot; Made by Proteus Technologies
   </footer>
 </main>
 

--- a/user-manual/script-statistics.html
+++ b/user-manual/script-statistics.html
@@ -274,7 +274,7 @@
 
   </div>
   <footer class="footer">
-    OpenDraft User Manual &middot; v0.26.1 &middot; Made by Proteus Technologies
+    OpenDraft User Manual &middot; v0.26.2 &middot; Made by Proteus Technologies
   </footer>
 </main>
 

--- a/user-manual/spell-check.html
+++ b/user-manual/spell-check.html
@@ -155,7 +155,7 @@
 
   </div>
   <footer class="footer">
-    OpenDraft User Manual &middot; v0.26.1 &middot; Made by Proteus Technologies
+    OpenDraft User Manual &middot; v0.26.2 &middot; Made by Proteus Technologies
   </footer>
 </main>
 

--- a/user-manual/tags.html
+++ b/user-manual/tags.html
@@ -188,7 +188,7 @@
 
   </div>
   <footer class="footer">
-    OpenDraft User Manual &middot; v0.26.1 &middot; Made by Proteus Technologies
+    OpenDraft User Manual &middot; v0.26.2 &middot; Made by Proteus Technologies
   </footer>
 </main>
 

--- a/user-manual/themes.html
+++ b/user-manual/themes.html
@@ -134,7 +134,7 @@
 
   </div>
   <footer class="footer">
-    OpenDraft User Manual &middot; v0.26.1 &middot; Made by Proteus Technologies
+    OpenDraft User Manual &middot; v0.26.2 &middot; Made by Proteus Technologies
   </footer>
 </main>
 

--- a/user-manual/title-page.html
+++ b/user-manual/title-page.html
@@ -215,7 +215,7 @@
 
   </div>
   <footer class="footer">
-    OpenDraft User Manual &middot; v0.26.1 &middot; Made by Proteus Technologies
+    OpenDraft User Manual &middot; v0.26.2 &middot; Made by Proteus Technologies
   </footer>
 </main>
 

--- a/user-manual/version-history.html
+++ b/user-manual/version-history.html
@@ -228,7 +228,7 @@
 
   </div>
   <footer class="footer">
-    OpenDraft User Manual &middot; v0.26.1 &middot; Made by Proteus Technologies
+    OpenDraft User Manual &middot; v0.26.2 &middot; Made by Proteus Technologies
   </footer>
 </main>
 

--- a/user-manual/writing-screenplay.html
+++ b/user-manual/writing-screenplay.html
@@ -371,7 +371,7 @@
 
   </div>
   <footer class="footer">
-    OpenDraft User Manual &middot; v0.26.1 &middot; Made by Proteus Technologies
+    OpenDraft User Manual &middot; v0.26.2 &middot; Made by Proteus Technologies
   </footer>
 </main>
 


### PR DESCRIPTION
Version bump to 0.26.2 and download links.

Merging this points README and the landing page at the 0.26.2 files, which are all present on the release. Until it lands, both still advertise 0.26.1 filenames and `releases/latest/download` resolves to v0.26.2, where `OpenDraft_0.26.1_x64.dmg`, `OpenDraft_0.26.1_x86_64-legacy.dmg` and `OpenDraft-0.26.1-1.x86_64.rpm` do not exist — so Intel Mac and RPM downloads are 404ing right now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LQwSexVvjtvqhHkpBaySDe