### PR TITLE
Handwriting panel, iPad selection handles, and Paste as Fountain (#90, #108, #109)

### DIFF
--- a/frontend/src/components/MenuBar.tsx
+++ b/frontend/src/components/MenuBar.tsx
@@ -1432,6 +1432,26 @@ const MenuBar: React.FC<MenuBarProps> = ({
     setOpenSubmenu(null);
   };
 
+  /**
+   * Keep the writer's selection where it is while they reach for a menu.
+   *
+   * Pressing a menu moves focus out of the editor by default. On iPadOS that
+   * costs the selection twice over: the highlight stops being painted, and —
+   * the part this fixes — WebKit collapses the DOM selection on the way out,
+   * ProseMirror's observer syncs the collapse into its own state, and the
+   * caret comes back somewhere other than where the writer left it. A menu
+   * that does not take focus leaves the selection exactly as it was.
+   *
+   * Same treatment as ElementPicker and CharacterAutocomplete: mousedown
+   * rather than pointerdown, because preventing the pointer event suppresses
+   * the click that follows it and the menu would stop responding at all.
+   * Nothing inside a menu wants focus of its own.
+   *
+   * It does not bring the highlight back — an unfocused view paints none
+   * regardless, which is what SelectionHandles' bands are for.
+   */
+  const keepEditorSelection = (e: React.MouseEvent) => e.preventDefault();
+
   const handleItemClick = (item: MenuItem, e: React.MouseEvent) => {
     e.stopPropagation();
     if (!item.disabled && item.action) {
@@ -2158,6 +2178,7 @@ const MenuBar: React.FC<MenuBarProps> = ({
           key={menu.label}
           ref={(el) => { menuItemRefs.current[menu.label] = el; }}
           className={`menu-item ${activeMenu === menu.label ? 'active' : ''}`}
+          onMouseDown={keepEditorSelection}
           onClick={() => handleMenuClick(menu.label)}
           onMouseEnter={() => {
             if (activeMenu) setActiveMenu(menu.label);
@@ -2170,6 +2191,7 @@ const MenuBar: React.FC<MenuBarProps> = ({
       <div
         ref={(el) => { menuItemRefs.current['Help'] = el; }}
         className={`menu-item ${activeMenu === 'Help' ? 'active' : ''}`}
+        onMouseDown={keepEditorSelection}
         onClick={() => handleMenuClick('Help')}
         onMouseEnter={() => {
           if (activeMenu) setActiveMenu('Help');
@@ -2233,6 +2255,7 @@ const MenuBar: React.FC<MenuBarProps> = ({
     {activeMenuData && createPortal(
       <div
         className={`menu-dropdown${toolbarMode === 'comfortable' ? ' menu-dropdown--comfortable' : ''}${dropdownPos.bottom != null ? ' menu-dropdown--above' : ''}`}
+        onMouseDown={keepEditorSelection}
         style={{ top: dropdownPos.top, bottom: dropdownPos.bottom, left: dropdownPos.left }}
       >
         {activeMenuData.items.map((item, i) =>

--- a/frontend/src/components/PencilCaret.tsx
+++ b/frontend/src/components/PencilCaret.tsx
@@ -32,6 +32,7 @@
  */
 import React, { useCallback, useEffect, useState } from 'react';
 import type { Editor } from '@tiptap/react';
+import { toPagePoint, type PagePoint } from '../utils/pageCoords';
 
 interface PencilCaretProps {
   editor: Editor | null;
@@ -39,14 +40,8 @@ interface PencilCaretProps {
   enabled: boolean;
 }
 
-interface CaretBox {
-  left: number;
-  top: number;
-  height: number;
-}
-
 const PencilCaret: React.FC<PencilCaretProps> = ({ editor, enabled }) => {
-  const [box, setBox] = useState<CaretBox | null>(null);
+  const [box, setBox] = useState<PagePoint | null>(null);
 
   const measure = useCallback(() => {
     if (!editor || !enabled) { setBox(null); return; }
@@ -66,23 +61,11 @@ const PencilCaret: React.FC<PencilCaretProps> = ({ editor, enabled }) => {
       // Read-only drafts hide the caret on purpose.
       if (!view.editable) { setBox(null); return; }
 
-      const coords = view.coordsAtPos(state.selection.head);
-      // Measured against the page, which is this element's offset parent.
+      // Measured against the page, which is this element's offset parent, and
+      // undone of whatever zoom is being applied to it — see pageCoords.ts.
       const page = dom.closest('.page') as HTMLElement | null;
       if (!page) { setBox(null); return; }
-      const rect = page.getBoundingClientRect();
-
-      // The painted width over the layout width is whatever scale an ancestor
-      // is applying — zoom, or none. Measured, so nothing here has to know how
-      // the page is being scaled or whether that has changed.
-      const scale = page.offsetWidth > 0 ? rect.width / page.offsetWidth : 1;
-      if (!Number.isFinite(scale) || scale <= 0) { setBox(null); return; }
-
-      setBox({
-        left: (coords.left - rect.left) / scale,
-        top: (coords.top - rect.top) / scale,
-        height: Math.max(8, (coords.bottom - coords.top) / scale),
-      });
+      setBox(toPagePoint(page, view.coordsAtPos(state.selection.head)));
     } catch {
       // coordsAtPos throws while the view is mid-update; the next tick re-reads.
       setBox(null);

--- a/frontend/src/components/PencilCaret.tsx
+++ b/frontend/src/components/PencilCaret.tsx
@@ -38,9 +38,19 @@ interface PencilCaretProps {
   editor: Editor | null;
   /** Touch device. Desktop carets work; leave them alone. */
   enabled: boolean;
+  /**
+   * Keep drawing while the editor does not hold focus.
+   *
+   * Only the handwriting panel sets this. Focus is in its writing field, so
+   * iPadOS paints nothing in the view behind — and that view is exactly where
+   * the writer needs to see the insertion point, because tapping a line there
+   * is how they choose where the next insert goes (issue #90). There is still
+   * only ever one caret: an unfocused view has none of its own to clash with.
+   */
+  showUnfocused?: boolean;
 }
 
-const PencilCaret: React.FC<PencilCaretProps> = ({ editor, enabled }) => {
+const PencilCaret: React.FC<PencilCaretProps> = ({ editor, enabled, showUnfocused = false }) => {
   const [box, setBox] = useState<PagePoint | null>(null);
 
   const measure = useCallback(() => {
@@ -54,7 +64,7 @@ const PencilCaret: React.FC<PencilCaretProps> = ({ editor, enabled }) => {
       const focused = document.activeElement === dom
         || dom.contains(document.activeElement)
         || dom.classList.contains('ProseMirror-focused');
-      if (!focused || !state.selection.empty) {
+      if ((!focused && !showUnfocused) || !state.selection.empty) {
         setBox(null);
         return;
       }
@@ -70,7 +80,7 @@ const PencilCaret: React.FC<PencilCaretProps> = ({ editor, enabled }) => {
       // coordsAtPos throws while the view is mid-update; the next tick re-reads.
       setBox(null);
     }
-  }, [editor, enabled]);
+  }, [editor, enabled, showUnfocused]);
 
   /** Coalesce the several events a single caret move fires into one measure. */
   /**

--- a/frontend/src/components/ScreenplayEditor.tsx
+++ b/frontend/src/components/ScreenplayEditor.tsx
@@ -652,11 +652,11 @@ const ScreenplayEditor: React.FC = () => {
     if (!isTouch) return;
     const handleThreeFingerTouch = (e: TouchEvent) => {
       if (e.touches.length === 3) {
-        // Not inside the handwriting sheet. It has its own selection and
+        // Not inside the handwriting panel. It has its own selection and
         // clipboard controls, and the field's native callout carries the
         // Pencil's own gestures — opening the script's context menu on top of
         // it would take both away.
-        if ((e.target as HTMLElement | null)?.closest?.('.scribble-overlay')) return;
+        if ((e.target as HTMLElement | null)?.closest?.('.scribble-panel')) return;
         e.preventDefault();
         // Use center of the three touches as position
         let cx = 0, cy = 0;
@@ -1081,8 +1081,13 @@ const ScreenplayEditor: React.FC = () => {
   const charAutoDismissedRef = useRef(false);
 
   const [formatPanelOpen, setFormatPanelOpen] = useState(false);
-  /** Where the handwriting sheet will insert what it converts, when open. */
-  const [scribbleTarget, setScribbleTarget] = useState<{ from: number; to: number } | null>(null);
+  /**
+   * Whether the handwriting panel is up. Only whether — where it inserts is the
+   * editor's live selection, read by the panel itself, because the panel is not
+   * modal and the writer moves the insertion point by tapping the script behind
+   * it (issue #90).
+   */
+  const [scribbleOpen, setScribbleOpen] = useState(false);
 
   // Script context menu state
   const [ctxMenuState, setCtxMenuState] = useState<{
@@ -3299,15 +3304,12 @@ const ScreenplayEditor: React.FC = () => {
     });
   }, [editor]);
 
-  // Open the handwriting sheet when the Edit menu or the touch context menu
-  // asks for it. The selection is read here, at the moment of the request,
-  // because focusing the sheet's writing field moves focus out of the editor.
+  // Open the handwriting panel when the Edit menu or the touch context menu
+  // asks for it. Asking again while it is open is a no-op rather than a reset:
+  // the panel already follows the selection, so there is nothing to re-capture.
   React.useEffect(() => {
     if (!editor) return;
-    const onRequest = () => {
-      const { from, to } = editor.state.selection;
-      setScribbleTarget({ from, to });
-    };
+    const onRequest = () => setScribbleOpen(true);
     window.addEventListener(HANDWRITING_EVENT, onRequest);
     return () => window.removeEventListener(HANDWRITING_EVENT, onRequest);
   }, [editor]);
@@ -4813,7 +4815,15 @@ const ScreenplayEditor: React.FC = () => {
                       keyboard is down, which is how the Pencil is used, so the
                       app draws one. A sibling of the editor, never inside it —
                       ProseMirror replaces its own children. */}
-                  <PencilCaret editor={editor} enabled={isTouch && !isHistoryMode} />
+                  <PencilCaret
+                    editor={editor}
+                    enabled={isTouch && !isHistoryMode}
+                    // While the handwriting panel is up the editor does not hold
+                    // focus — the writing field does — but the writer still has
+                    // to see which line the next insert lands on, and iPadOS
+                    // draws nothing for an unfocused view.
+                    showUnfocused={scribbleOpen}
+                  />
                   {/* And no selection handles either, so the app draws those
                       too — see SelectionHandles.tsx. Same reason it is a
                       sibling and not a child of the editor. */}
@@ -4875,11 +4885,10 @@ const ScreenplayEditor: React.FC = () => {
           toolbar because it has to be reachable whatever else is on screen —
           notably with a hardware keyboard attached, where no on-screen
           accessory bar is showing at all (issue #90). */}
-      {scribbleTarget && editor && (
+      {scribbleOpen && editor && (
         <ScribbleInput
           editor={editor}
-          target={scribbleTarget}
-          onClose={() => setScribbleTarget(null)}
+          onClose={() => setScribbleOpen(false)}
         />
       )}
       {/* Context menu on mobile: 3-finger touch only */}

--- a/frontend/src/components/ScreenplayEditor.tsx
+++ b/frontend/src/components/ScreenplayEditor.tsx
@@ -79,6 +79,7 @@ import GrammarRulesPanel from './GrammarRulesPanel';
 import ScriptContextMenu from './ScriptContextMenu';
 import ScribbleInput from './ScribbleInput';
 import PencilCaret from './PencilCaret';
+import SelectionHandles from './SelectionHandles';
 import { useFootnotePlan } from '../hooks/useFootnotePlan';
 import { footnotePlanSignature, type FootnotePlan } from '../utils/footnotes';
 import { createFootnoteMarkerPlugin } from '../editor/footnoteMarkers';
@@ -164,7 +165,7 @@ import { useIsTouchDevice, useSwipeEdge, usePinchZoom } from '../hooks/useTouch'
 import { useSettingsStore } from '../stores/settingsStore';
 import { startCollabSync, stopCollabSync } from '../services/collabSync';
 import { collabAuthApi, setLogoutCollabTeardown, setLogoutEditorReset, isCollabAuthenticated } from '../services/collabAuth';
-import { platformFetch, isTauri, isDesktopTauri } from '../services/platform';
+import { platformFetch, isTauri, isDesktopTauri, needsSelectionHandles } from '../services/platform';
 import { reportSaveError } from '../stores/saveErrorStore';
 import { pluginRegistry } from '../plugins/registry';
 import { createTrackChangesPlugin, trackChangesPluginKey } from '../editor/trackChanges';
@@ -4326,9 +4327,14 @@ const ScreenplayEditor: React.FC = () => {
     const handleContextMenu = (e: MouseEvent) => {
       const editorDom = editor.view.dom;
       if (!editorDom.contains(e.target as Node)) return;
-      e.preventDefault();
-      // No context menu on touch devices — use 3-finger touch instead
+      // No context menu on touch devices — three fingers opens it instead —
+      // and nothing prevented either. On iPadOS the long press that fires this
+      // event is the same gesture that selects a word and puts the selection
+      // UI on screen, so preventing it here took the selection handles with it
+      // (issue #108). This used to run before the check, which meant that on a
+      // touch device the handler did nothing *but* cancel the gesture.
       if (isTouchDevice) return;
+      e.preventDefault();
 
       // Move cursor to click position only if no text is selected,
       // or if the click is outside the current selection
@@ -4808,6 +4814,13 @@ const ScreenplayEditor: React.FC = () => {
                       app draws one. A sibling of the editor, never inside it —
                       ProseMirror replaces its own children. */}
                   <PencilCaret editor={editor} enabled={isTouch && !isHistoryMode} />
+                  {/* And no selection handles either, so the app draws those
+                      too — see SelectionHandles.tsx. Same reason it is a
+                      sibling and not a child of the editor. */}
+                  <SelectionHandles
+                    editor={editor}
+                    enabled={needsSelectionHandles() && !isHistoryMode}
+                  />
                 </div>
               </div>
               </div>

--- a/frontend/src/components/ScribbleInput.tsx
+++ b/frontend/src/components/ScribbleInput.tsx
@@ -33,8 +33,8 @@
 import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import type { Editor } from '@tiptap/react';
 import {
-  FaArrowLeft, FaChevronDown, FaChevronUp, FaCopy, FaCut, FaKeyboard, FaLevelDownAlt,
-  FaPaste, FaTextWidth, FaTimes,
+  FaArrowLeft, FaChevronDown, FaChevronUp, FaCog, FaCopy, FaCut, FaKeyboard,
+  FaLevelDownAlt, FaPaste, FaTextWidth, FaTimes,
 } from 'react-icons/fa';
 import { ELEMENT_LABELS } from '../stores/editorStore';
 import { readClipboardText, writeClipboard } from '../utils/clipboardCommands';
@@ -56,6 +56,80 @@ const KEYBOARD_PREF_KEY = 'opendraft:handwritingKeyboard';
 /** Where the writer last dragged the panel, and whether they kept the preview. */
 const POSITION_PREF_KEY = 'opendraft:handwritingPos';
 const PREVIEW_PREF_KEY = 'opendraft:handwritingPreview';
+/** The size the writer last dragged the panel to. */
+const SIZE_PREF_KEY = 'opendraft:handwritingSize';
+/** How much of the script shows through the panel, and through the field. */
+const PANEL_ALPHA_KEY = 'opendraft:handwritingPanelAlpha';
+const AREA_ALPHA_KEY = 'opendraft:handwritingAreaAlpha';
+/** What colour the handwriting comes out in. */
+const INK_KEY = 'opendraft:handwritingInk';
+
+/**
+ * Smallest the panel is any use at: narrower and a line of dialogue wraps
+ * twice, shorter and there is no room to write at hand size.
+ */
+const MIN_PANEL: PanelSize = { width: 300, height: 240 };
+
+/**
+ * Below this the tool buttons drop their words and keep their icons. Measured
+ * on the panel rather than the window: it is the panel the buttons have to fit
+ * across, and the writer can now make that any width they like.
+ */
+const COMPACT_WIDTH = 470;
+
+/**
+ * Ink the writer can pick from.
+ *
+ * The panel is see-through now, so what is behind the field is the script —
+ * and handwriting in the same colour as the text underneath is unreadable
+ * against it. These are chosen to stay legible over black text on white paper.
+ */
+const INKS: { label: string; value: string }[] = [
+  { label: 'Default', value: '' },
+  { label: 'Blue', value: '#1d4ed8' },
+  { label: 'Red', value: '#dc2626' },
+  { label: 'Green', value: '#15803d' },
+  { label: 'Purple', value: '#7c3aed' },
+];
+
+function loadNumber(key: string, fallback: number, lo: number, hi: number): number {
+  try {
+    const raw = localStorage.getItem(key);
+    if (raw === null) return fallback;
+    const n = Number(raw);
+    return Number.isFinite(n) ? Math.min(hi, Math.max(lo, n)) : fallback;
+  } catch {
+    return fallback;
+  }
+}
+
+function saveValue(key: string, value: string): void {
+  try {
+    localStorage.setItem(key, value);
+  } catch {
+    /* private mode — the panel still works, the choice just will not stick */
+  }
+}
+
+function loadString(key: string, fallback: string): string {
+  try {
+    return localStorage.getItem(key) ?? fallback;
+  } catch {
+    return fallback;
+  }
+}
+
+function loadSize(): PanelSize | null {
+  try {
+    const raw = localStorage.getItem(SIZE_PREF_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as Partial<PanelSize>;
+    if (typeof parsed?.width !== 'number' || typeof parsed?.height !== 'number') return null;
+    return { width: parsed.width, height: parsed.height };
+  } catch {
+    return null;
+  }
+}
 
 function loadFlag(key: string, fallback: boolean): boolean {
   try {
@@ -266,11 +340,77 @@ const ScribbleInput: React.FC<ScribbleInputProps> = ({ editor, onClose }) => {
   const [pos, setPos] = useState<PanelPos | null>(null);
   const dragRef = useRef<{ dx: number; dy: number } | null>(null);
 
+
+
   const panelSize = useCallback((): PanelSize => {
     const el = panelRef.current;
     const rect = el?.getBoundingClientRect();
     return { width: Math.round(rect?.width ?? 0), height: Math.round(rect?.height ?? 0) };
   }, []);
+
+  // ── Size, and what shows through ────────────────────────────────────────
+  const [size, setSize] = useState<PanelSize | null>(loadSize);
+  const resizeRef = useRef<{ x: number; y: number; w: number; h: number } | null>(null);
+  const [compact, setCompact] = useState(false);
+  const [settingsOpen, setSettingsOpen] = useState(false);
+  const [panelAlpha, setPanelAlpha] = useState(() => loadNumber(PANEL_ALPHA_KEY, 1, 0.2, 1));
+  const [areaAlpha, setAreaAlpha] = useState(() => loadNumber(AREA_ALPHA_KEY, 1, 0, 1));
+  const [ink, setInk] = useState(() => loadString(INK_KEY, ''));
+
+  /**
+   * The words on the tool buttons come and go with the width of the panel, not
+   * the width of the window: the writer sets the panel's width now, and six
+   * labelled buttons in a 320px panel wrap into an unusable stack.
+   */
+  useEffect(() => {
+    const el = panelRef.current;
+    if (!el || typeof ResizeObserver === 'undefined') return;
+    const ro = new ResizeObserver(([entry]) => {
+      setCompact(entry.contentRect.width < COMPACT_WIDTH);
+    });
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, []);
+
+  /** Held within the viewport as well as the minimum, so a corner dragged far
+   *  past the edge cannot leave the panel bigger than the screen it is on. */
+  const clampSize = useCallback((want: PanelSize): PanelSize => {
+    const view = viewportSize();
+    return {
+      width: Math.round(Math.min(Math.max(want.width, MIN_PANEL.width), view.width - 16)),
+      height: Math.round(Math.min(Math.max(want.height, MIN_PANEL.height), view.height - 16)),
+    };
+  }, []);
+
+  const onResizeStart = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
+    const rect = panelRef.current?.getBoundingClientRect();
+    if (!rect) return;
+    e.preventDefault();
+    e.stopPropagation();
+    resizeRef.current = { x: e.clientX, y: e.clientY, w: rect.width, h: rect.height };
+    e.currentTarget.setPointerCapture(e.pointerId);
+  }, []);
+
+  const onResizeMove = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
+    const r = resizeRef.current;
+    if (!r) return;
+    e.preventDefault();
+    setSize(clampSize({ width: r.w + (e.clientX - r.x), height: r.h + (e.clientY - r.y) }));
+  }, [clampSize]);
+
+  const onResizeEnd = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
+    if (!resizeRef.current) return;
+    resizeRef.current = null;
+    if (e.currentTarget.hasPointerCapture(e.pointerId)) {
+      e.currentTarget.releasePointerCapture(e.pointerId);
+    }
+    setSize((current) => {
+      if (current) saveValue(SIZE_PREF_KEY, JSON.stringify(current));
+      return current;
+    });
+    // A panel grown from the bottom-right can push its own header off screen.
+    setPos((prev) => (prev ? clampPanelPosition(prev, panelSize(), viewportSize()) : prev));
+  }, [panelSize]);
 
   // Measured before paint, so the panel never shows in one place and jumps to
   // another. A saved position is honoured; a first-ever open goes to the foot.
@@ -421,28 +561,6 @@ const ScribbleInput: React.FC<ScribbleInputProps> = ({ editor, onClose }) => {
     });
   }, []);
 
-  /**
-   * Scroll the script so the caret is not left under the panel.
-   *
-   * ProseMirror's own `scrollIntoView` counts anything inside the window as
-   * visible, and the panel floats over the window — so the line just written
-   * into can be perfectly "in view" and completely hidden. Only ever scrolls
-   * the line up out from under the panel; a caret above it is left alone.
-   */
-  const revealCaret = useCallback(() => {
-    try {
-      const panel = panelRef.current?.getBoundingClientRect();
-      const main = editor.view.dom.closest('.editor-main') as HTMLElement | null;
-      if (!panel || !main) return;
-      const caret = editor.view.coordsAtPos(editor.state.selection.head);
-      const clearance = 24;
-      if (caret.bottom <= panel.top - clearance) return;
-      main.scrollTop += caret.bottom - (panel.top - clearance);
-    } catch {
-      /* the text is in; not scrolling to it is a small loss */
-    }
-  }, [editor]);
-
   const handleInsert = useCallback(() => {
     const paragraphs = splitHandwriting(text);
     if (paragraphs.length === 0) {
@@ -492,12 +610,18 @@ const ScribbleInput: React.FC<ScribbleInputProps> = ({ editor, onClose }) => {
 
     setText('');
     requestAnimationFrame(() => {
-      revealCaret();
+      // The script is deliberately left exactly where it was. It used to be
+      // scrolled so the caret cleared the panel, which moved the page out from
+      // under the writer at the moment they were looking for what had just
+      // landed — the one moment the view needs to hold still. Where to put the
+      // panel so it does not cover the work is the writer's call, and they can
+      // drag and now resize it to make that call.
+      //
       // Back to the field, so the next sentence can be written without a tap.
       areaRef.current?.focus();
       trackSelection();
     });
-  }, [editor, text, revealCaret, trackSelection]);
+  }, [editor, text, trackSelection]);
 
   // Escape closes — it is a deliberate "I am done here", which is the bar the
   // panel holds everything else to.
@@ -519,11 +643,17 @@ const ScribbleInput: React.FC<ScribbleInputProps> = ({ editor, onClose }) => {
     // stray Pencil tip landing outside used to throw away everything written
     // in it.)
     <div
-      className="scribble-panel"
+      className={`scribble-panel${compact ? ' is-compact' : ''}`}
       ref={panelRef}
       role="dialog"
       aria-label="Handwriting input"
-      style={pos ? { left: pos.left, top: pos.top } : { visibility: 'hidden' }}
+      style={{
+        ...(pos ? { left: pos.left, top: pos.top } : { visibility: 'hidden' }),
+        ...(size ? { width: size.width, height: size.height } : {}),
+        '--scribble-panel-alpha': String(panelAlpha),
+        '--scribble-area-alpha': String(areaAlpha),
+        ...(ink ? { '--scribble-ink': ink } : {}),
+      } as unknown as React.CSSProperties}
     >
       <div
         className="scribble-header"
@@ -559,6 +689,16 @@ const ScribbleInput: React.FC<ScribbleInputProps> = ({ editor, onClose }) => {
             </button>
             <button
               type="button"
+              className={`scribble-close${settingsOpen ? ' is-on' : ''}`}
+              onClick={() => setSettingsOpen((o) => !o)}
+              aria-label="Handwriting settings"
+              aria-expanded={settingsOpen}
+              title="Transparency and ink"
+            >
+              <FaCog />
+            </button>
+            <button
+              type="button"
               className="scribble-close"
               onClick={onClose}
               aria-label="Close handwriting"
@@ -568,6 +708,56 @@ const ScribbleInput: React.FC<ScribbleInputProps> = ({ editor, onClose }) => {
             </button>
           </div>
         </div>
+
+        {/* Transparency and ink. The panel covers the script, so how much of
+            it shows through — and what colour the handwriting has to stay
+            legible against whatever does — is the writer's call, not a fixed
+            choice. Kept in the header so it never moves with the field. */}
+        {settingsOpen && (
+          <div className="scribble-settings" onPointerDown={(e) => e.stopPropagation()}>
+            <label className="scribble-setting">
+              <span>Panel</span>
+              <input
+                type="range" min={0.2} max={1} step={0.05} value={panelAlpha}
+                onChange={(e) => {
+                  const v = Number(e.target.value);
+                  setPanelAlpha(v);
+                  saveValue(PANEL_ALPHA_KEY, String(v));
+                }}
+                aria-label="Panel opacity"
+              />
+            </label>
+            <label className="scribble-setting">
+              <span>Writing area</span>
+              <input
+                type="range" min={0} max={1} step={0.05} value={areaAlpha}
+                onChange={(e) => {
+                  const v = Number(e.target.value);
+                  setAreaAlpha(v);
+                  saveValue(AREA_ALPHA_KEY, String(v));
+                }}
+                aria-label="Writing area opacity"
+              />
+            </label>
+            <div className="scribble-setting scribble-inks">
+              <span>Ink</span>
+              <div className="scribble-ink-row">
+                {INKS.map((c) => (
+                  <button
+                    key={c.label}
+                    type="button"
+                    className={`scribble-ink${ink === c.value ? ' is-on' : ''}${c.value ? '' : ' is-default'}`}
+                    style={c.value ? { background: c.value } : undefined}
+                    onClick={() => { setInk(c.value); saveValue(INK_KEY, c.value); }}
+                    aria-label={`${c.label} ink`}
+                    aria-pressed={ink === c.value}
+                    title={c.label}
+                  />
+                ))}
+              </div>
+            </div>
+          </div>
+        )}
 
         {/* The script either side of where this lands, in the editor's own
             element styles and page metrics. It follows the caret: tap a
@@ -627,31 +817,44 @@ const ScribbleInput: React.FC<ScribbleInputProps> = ({ editor, onClose }) => {
           its own palette for native fields, but not for a field inside a web
           view, so the app has to supply the equivalents. */}
       <div className="scribble-tools">
-        <button type="button" className="scribble-tool scribble-tool-key" onClick={() => replaceSelection('\n')}>
-          <FaLevelDownAlt style={{ transform: 'rotate(90deg)' }} /> Enter
+        <button type="button" className="scribble-tool scribble-tool-key" onClick={() => replaceSelection('\n')} aria-label="Enter" title="Enter">
+          <FaLevelDownAlt style={{ transform: 'rotate(90deg)' }} /><span className="scribble-tool-label">Enter</span>
         </button>
         <button
           type="button"
           className="scribble-tool scribble-tool-key"
-          onClick={() => replaceSelection('', true)}
+          onClick={() => replaceSelection('', true)} aria-label="Backspace" title="Backspace"
           disabled={text === ''}
         >
-          <FaArrowLeft /> Backspace
+          <FaArrowLeft /><span className="scribble-tool-label">Backspace</span>
         </button>
         <span className="scribble-tools-gap" />
-        <button type="button" className="scribble-tool" onClick={handleSelectAll} disabled={text === ''}>
-          <FaTextWidth /> Select All
+        <button type="button" className="scribble-tool" onClick={handleSelectAll} aria-label="Select All" title="Select All" disabled={text === ''}>
+          <FaTextWidth /><span className="scribble-tool-label">Select All</span>
         </button>
-        <button type="button" className="scribble-tool" onClick={() => void handleCut()} disabled={!hasSelection}>
-          <FaCut /> Cut
+        <button type="button" className="scribble-tool" onClick={() => void handleCut()} aria-label="Cut" title="Cut" disabled={!hasSelection}>
+          <FaCut /><span className="scribble-tool-label">Cut</span>
         </button>
-        <button type="button" className="scribble-tool" onClick={() => void handleCopy()} disabled={!hasSelection}>
-          <FaCopy /> Copy
+        <button type="button" className="scribble-tool" onClick={() => void handleCopy()} aria-label="Copy" title="Copy" disabled={!hasSelection}>
+          <FaCopy /><span className="scribble-tool-label">Copy</span>
         </button>
-        <button type="button" className="scribble-tool" onClick={() => void handlePaste()}>
-          <FaPaste /> Paste
+        <button type="button" className="scribble-tool" onClick={() => void handlePaste()} aria-label="Paste" title="Paste">
+          <FaPaste /><span className="scribble-tool-label">Paste</span>
         </button>
       </div>
+
+      {/* Drag the corner to resize. The panel floats over the script, so how
+          much of the page it is allowed to cover is the writer's decision —
+          the same decision dragging it around already was. */}
+      <div
+        className="scribble-resize"
+        onPointerDown={onResizeStart}
+        onPointerMove={onResizeMove}
+        onPointerUp={onResizeEnd}
+        onPointerCancel={onResizeEnd}
+        role="separator"
+        aria-label="Resize handwriting panel"
+      />
 
       <div className="scribble-actions">
         {/* Clear rather than Cancel: leaving is the close button's job now, and

--- a/frontend/src/components/ScribbleInput.tsx
+++ b/frontend/src/components/ScribbleInput.tsx
@@ -39,7 +39,7 @@ import {
 import { ELEMENT_LABELS } from '../stores/editorStore';
 import { readClipboardText, writeClipboard } from '../utils/clipboardCommands';
 import {
-  clampPanelPosition, defaultPanelPosition, splitHandwriting,
+  clampPanelPosition, defaultPanelPosition, joinHandwriting, splitHandwriting,
   type PanelPos, type PanelSize,
 } from '../utils/handwriting';
 import { showToast } from './Toast';
@@ -460,8 +460,19 @@ const ScribbleInput: React.FC<ScribbleInputProps> = ({ editor, onClose }) => {
     // reverting to a default.
     const elementType = editor.state.doc.resolve(from).parent.type.name;
 
+    // A single line joins the sentence the caret is in, so it is spaced into
+    // it. The characters either side come from `textBetween`, which stops at a
+    // block boundary and hands back '' — nothing to join to at the start or the
+    // end of a line, which is exactly the answer wanted there.
+    //
+    // Several lines become blocks of their own; nothing runs together, so
+    // nothing needs spacing.
     const content = paragraphs.length === 1
-      ? paragraphs[0]
+      ? joinHandwriting(
+        paragraphs[0],
+        from > 0 ? editor.state.doc.textBetween(from - 1, from) : '',
+        to < editor.state.doc.content.size ? editor.state.doc.textBetween(to, to + 1) : '',
+      )
       : paragraphs.map((p) => ({
         type: elementType,
         content: [{ type: 'text', text: p }],

--- a/frontend/src/components/ScribbleInput.tsx
+++ b/frontend/src/components/ScribbleInput.tsx
@@ -12,50 +12,95 @@
  *
  * The fix is not to make the page a better Scribble target — the space simply
  * is not there — but to hand the Pencil somewhere that has nothing to destroy.
- * This sheet is a single empty text field, large enough to write at a natural
- * hand size. Nothing follows the caret inside it, so nothing can be
- * overwritten. What it converts is inserted into the script at the position the
- * writer had selected when they opened it.
+ * This is a single empty text field, large enough to write at a natural hand
+ * size. Nothing follows the caret inside it, so nothing can be overwritten.
+ * What it converts is inserted into the script at the writer's own position.
+ *
+ * It is a floating panel rather than a modal sheet, and that is the whole shape
+ * of it: a modal one had to be closed before the script could be touched, so
+ * every edit cost a reopen, and revising a scene meant the same four taps over
+ * and over. This one stays up. Tapping a line in the script behind it moves
+ * where the next insert lands — the panel follows the editor's own selection
+ * rather than a position captured when it opened — so one panel serves a whole
+ * pass over a script. Insert leaves it open and empty, ready for the next one.
  *
  * Above the field is a preview of the script either side of that position,
  * drawn with the editor's own element classes and page metrics so a Character
- * cue sits where a Character cue sits. Looking away from the page costs the
- * writer their place; this hands it back.
+ * cue sits where a Character cue sits. The panel covers part of the page, and
+ * the writer's eye is in the panel; this says what is about to happen without
+ * asking them to look away and find their place again.
  */
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { TextSelection } from '@tiptap/pm/state';
+import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import type { Editor } from '@tiptap/react';
 import {
-  FaArrowLeft, FaCopy, FaCut, FaKeyboard, FaLevelDownAlt, FaPaste, FaTextWidth,
+  FaArrowLeft, FaChevronDown, FaChevronUp, FaCopy, FaCut, FaKeyboard, FaLevelDownAlt,
+  FaPaste, FaTextWidth, FaTimes,
 } from 'react-icons/fa';
 import { ELEMENT_LABELS } from '../stores/editorStore';
 import { readClipboardText, writeClipboard } from '../utils/clipboardCommands';
+import {
+  clampPanelPosition, defaultPanelPosition, splitHandwriting,
+  type PanelPos, type PanelSize,
+} from '../utils/handwriting';
 import { showToast } from './Toast';
 import TextareaCaret from './TextareaCaret';
 
 /**
  * Whether tapping the field should raise the on-screen keyboard.
  *
- * Off by default: this sheet exists for the Pencil, and a keyboard covering
+ * Off by default: this panel exists for the Pencil, and a keyboard covering
  * two thirds of the iPad is the opposite of what it is for. The preference is
  * remembered because which one a writer wants is a habit, not a per-use choice.
  */
 const KEYBOARD_PREF_KEY = 'opendraft:handwritingKeyboard';
+/** Where the writer last dragged the panel, and whether they kept the preview. */
+const POSITION_PREF_KEY = 'opendraft:handwritingPos';
+const PREVIEW_PREF_KEY = 'opendraft:handwritingPreview';
 
-function loadKeyboardPref(): boolean {
+function loadFlag(key: string, fallback: boolean): boolean {
   try {
-    return localStorage.getItem(KEYBOARD_PREF_KEY) === '1';
+    const raw = localStorage.getItem(key);
+    return raw === null ? fallback : raw === '1';
   } catch {
-    return false;
+    return fallback;
   }
 }
 
-function saveKeyboardPref(on: boolean): void {
+function saveFlag(key: string, on: boolean): void {
   try {
-    localStorage.setItem(KEYBOARD_PREF_KEY, on ? '1' : '0');
+    localStorage.setItem(key, on ? '1' : '0');
   } catch {
-    /* private mode — the sheet still works, the choice just will not stick */
+    /* private mode — the panel still works, the choice just will not stick */
   }
+}
+
+function loadPosition(): PanelPos | null {
+  try {
+    const raw = localStorage.getItem(POSITION_PREF_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as Partial<PanelPos>;
+    if (typeof parsed?.left !== 'number' || typeof parsed?.top !== 'number') return null;
+    return { left: parsed.left, top: parsed.top };
+  } catch {
+    return null;
+  }
+}
+
+function savePosition(pos: PanelPos): void {
+  try {
+    localStorage.setItem(POSITION_PREF_KEY, JSON.stringify(pos));
+  } catch {
+    /* as above */
+  }
+}
+
+/** The visible area, which the software keyboard shrinks from the bottom. */
+function viewportSize() {
+  const vv = window.visualViewport;
+  return {
+    width: Math.round(vv?.width ?? window.innerWidth),
+    height: Math.round(vv?.height ?? window.innerHeight),
+  };
 }
 
 /** How many blocks of script to show either side of the insertion point. */
@@ -83,28 +128,61 @@ interface PreviewBlock {
 
 interface ScribbleInputProps {
   editor: Editor;
-  /** Where the converted text goes — captured before this sheet took focus. */
-  target: { from: number; to: number };
   onClose: () => void;
 }
 
-const ScribbleInput: React.FC<ScribbleInputProps> = ({ editor, target, onClose }) => {
+const ScribbleInput: React.FC<ScribbleInputProps> = ({ editor, onClose }) => {
   const [text, setText] = useState('');
-  const [keyboardOn, setKeyboardOn] = useState(loadKeyboardPref);
+  const [keyboardOn, setKeyboardOn] = useState(() => loadFlag(KEYBOARD_PREF_KEY, false));
+  const [previewOn, setPreviewOn] = useState(() => loadFlag(PREVIEW_PREF_KEY, true));
   const [hasSelection, setHasSelection] = useState(false);
   const areaRef = useRef<HTMLTextAreaElement>(null);
   const previewRef = useRef<HTMLDivElement>(null);
+  const panelRef = useRef<HTMLDivElement>(null);
 
   /**
-   * The script around the insertion point, read once: the document cannot
-   * change while this sheet is up, so there is nothing to recompute.
+   * Where the converted text goes. Read from the editor rather than captured on
+   * open, because the panel stays up while the writer taps around the script:
+   * the insertion point is wherever they last put it, and the preview has to
+   * agree with the caret they can see on the page.
    */
+  const [target, setTarget] = useState(() => {
+    const { from, to } = editor.state.selection;
+    return { from, to };
+  });
+  /**
+   * The document the preview was drawn from. Held as state rather than read
+   * through `editor.state` so that an edit made elsewhere — a collaborator, an
+   * undo, the writer's own last insert — redraws it.
+   */
+  const [doc, setDoc] = useState(() => editor.state.doc);
+
+  useEffect(() => {
+    const syncTarget = () => {
+      const { from, to } = editor.state.selection;
+      setTarget((prev) => (prev.from === from && prev.to === to ? prev : { from, to }));
+    };
+    const onTransaction = ({ transaction }: { transaction: { docChanged: boolean } }) => {
+      // Positions are remapped by ProseMirror, so re-reading the live selection
+      // is all it takes to stay pointed at the same place in the text.
+      syncTarget();
+      if (transaction.docChanged) setDoc(editor.state.doc);
+    };
+    editor.on('selectionUpdate', syncTarget);
+    editor.on('transaction', onTransaction);
+    return () => {
+      editor.off('selectionUpdate', syncTarget);
+      editor.off('transaction', onTransaction);
+    };
+  }, [editor]);
+
+  /** The script around the insertion point, as it stands now. */
   const { blocks, elementLabel } = useMemo(() => {
     const out: PreviewBlock[] = [];
     let label = '';
     try {
-      const { doc } = editor.state;
-      const $from = doc.resolve(target.from);
+      const from = Math.min(target.from, doc.content.size);
+      const $from = doc.resolve(from);
       // Depth 1 is the top-level block; a nested position (a dual-dialogue
       // column) still has one, which is the row the writer is actually in.
       const depth = Math.max(1, $from.depth);
@@ -126,9 +204,9 @@ const ScribbleInput: React.FC<ScribbleInputProps> = ({ editor, target, onClose }
           typeName: node.type.name,
           label: ELEMENT_LABELS[node.type.name] ?? node.type.name,
           text: blockText,
-          caretAt: isCaretBlock ? clamp(target.from - start - 1, 0, blockText.length) : null,
-          replacing: isCaretBlock && target.to > target.from
-            ? doc.textBetween(target.from, Math.min(target.to, start + 1 + blockText.length), ' ')
+          caretAt: isCaretBlock ? clamp(from - start - 1, 0, blockText.length) : null,
+          replacing: isCaretBlock && target.to > from
+            ? doc.textBetween(from, Math.min(target.to, start + 1 + blockText.length), ' ')
             : null,
         });
       }
@@ -136,7 +214,7 @@ const ScribbleInput: React.FC<ScribbleInputProps> = ({ editor, target, onClose }
       /* a preview is a courtesy; never let it stop the writer writing */
     }
     return { blocks: out, elementLabel: label };
-  }, [editor, target]);
+  }, [doc, target]);
 
   /**
    * The page's own metrics. Element indents are absolute inches offset against
@@ -165,19 +243,89 @@ const ScribbleInput: React.FC<ScribbleInputProps> = ({ editor, target, onClose }
   }, []);
 
   // The preview shows blocks either side of the target, so the target itself
-  // can start out scrolled past. Put it in view before the writer looks.
+  // can start out scrolled past. Put it in view before the writer looks — and
+  // again whenever they move the insertion point, which they now can without
+  // closing anything.
   useEffect(() => {
     const box = previewRef.current;
     const line = box?.querySelector('.is-target') as HTMLElement | null;
     if (!box || !line) return;
     // Its own scrollTop rather than scrollIntoView: that walks every scrollable
-    // ancestor, and the sheet is rendered inside the editor's tree, so it can
-    // jog the page behind the overlay while centring a line in front of it.
+    // ancestor, and the panel is rendered inside the editor's tree, so it can
+    // jog the page behind it while centring a line in front.
     box.scrollTop = Math.max(
       0,
       line.offsetTop - box.clientHeight / 2 + line.offsetHeight / 2,
     );
-  }, [blocks]);
+  }, [blocks, previewOn]);
+
+  // ── Where the panel sits ────────────────────────────────────────────────
+  // Free-floating and dragged by its header, because what it must not cover is
+  // the part of the script the writer is working on, and only they know which
+  // part that is.
+  const [pos, setPos] = useState<PanelPos | null>(null);
+  const dragRef = useRef<{ dx: number; dy: number } | null>(null);
+
+  const panelSize = useCallback((): PanelSize => {
+    const el = panelRef.current;
+    const rect = el?.getBoundingClientRect();
+    return { width: Math.round(rect?.width ?? 0), height: Math.round(rect?.height ?? 0) };
+  }, []);
+
+  // Measured before paint, so the panel never shows in one place and jumps to
+  // another. A saved position is honoured; a first-ever open goes to the foot.
+  useLayoutEffect(() => {
+    const size = panelSize();
+    if (size.width === 0) return;
+    const view = viewportSize();
+    const saved = loadPosition();
+    setPos(saved ? clampPanelPosition(saved, size, view) : defaultPanelPosition(size, view));
+  }, [panelSize]);
+
+  // A rotation, a window resize, or the keyboard coming up can leave the panel
+  // hanging off the edge with its controls out of reach.
+  useEffect(() => {
+    const reclamp = () => {
+      setPos((prev) => (prev ? clampPanelPosition(prev, panelSize(), viewportSize()) : prev));
+    };
+    window.addEventListener('resize', reclamp);
+    window.visualViewport?.addEventListener('resize', reclamp);
+    return () => {
+      window.removeEventListener('resize', reclamp);
+      window.visualViewport?.removeEventListener('resize', reclamp);
+    };
+  }, [panelSize]);
+
+  const onDragStart = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
+    // The header carries buttons; a tap on one of those is not a drag.
+    if ((e.target as HTMLElement).closest('button')) return;
+    const rect = panelRef.current?.getBoundingClientRect();
+    if (!rect) return;
+    dragRef.current = { dx: e.clientX - rect.left, dy: e.clientY - rect.top };
+    e.currentTarget.setPointerCapture(e.pointerId);
+    e.preventDefault();
+  }, []);
+
+  const onDragMove = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
+    const drag = dragRef.current;
+    if (!drag) return;
+    e.preventDefault();
+    setPos(clampPanelPosition(
+      { left: e.clientX - drag.dx, top: e.clientY - drag.dy },
+      panelSize(),
+      viewportSize(),
+    ));
+  }, [panelSize]);
+
+  const onDragEnd = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
+    if (!dragRef.current) return;
+    dragRef.current = null;
+    try { e.currentTarget.releasePointerCapture(e.pointerId); } catch { /* already gone */ }
+    setPos((prev) => {
+      if (prev) savePosition(prev);
+      return prev;
+    });
+  }, []);
 
   // Focus on open so the Pencil has a live field to write into straight away,
   // rather than the writer having to tap the box first.
@@ -251,7 +399,7 @@ const ScribbleInput: React.FC<ScribbleInputProps> = ({ editor, target, onClose }
   const toggleKeyboard = useCallback(() => {
     setKeyboardOn((on) => {
       const next = !on;
-      saveKeyboardPref(next);
+      saveFlag(KEYBOARD_PREF_KEY, next);
       const el = areaRef.current;
       if (el) {
         const start = el.selectionStart;
@@ -266,25 +414,54 @@ const ScribbleInput: React.FC<ScribbleInputProps> = ({ editor, target, onClose }
     });
   }, []);
 
+  const togglePreview = useCallback(() => {
+    setPreviewOn((on) => {
+      saveFlag(PREVIEW_PREF_KEY, !on);
+      return !on;
+    });
+  }, []);
+
+  /**
+   * Scroll the script so the caret is not left under the panel.
+   *
+   * ProseMirror's own `scrollIntoView` counts anything inside the window as
+   * visible, and the panel floats over the window — so the line just written
+   * into can be perfectly "in view" and completely hidden. Only ever scrolls
+   * the line up out from under the panel; a caret above it is left alone.
+   */
+  const revealCaret = useCallback(() => {
+    try {
+      const panel = panelRef.current?.getBoundingClientRect();
+      const main = editor.view.dom.closest('.editor-main') as HTMLElement | null;
+      if (!panel || !main) return;
+      const caret = editor.view.coordsAtPos(editor.state.selection.head);
+      const clearance = 24;
+      if (caret.bottom <= panel.top - clearance) return;
+      main.scrollTop += caret.bottom - (panel.top - clearance);
+    } catch {
+      /* the text is in; not scrolling to it is a small loss */
+    }
+  }, [editor]);
+
   const handleInsert = useCallback(() => {
-    const written = text.trim();
-    if (written === '') {
-      onClose();
+    const paragraphs = splitHandwriting(text);
+    if (paragraphs.length === 0) {
+      setText('');
       return;
     }
 
-    // The element the caret was in decides what new paragraphs become, so a
+    // Read at the moment of the insert, not when the panel opened: the writer
+    // may have tapped somewhere else in the script since, which is the point of
+    // the panel staying up.
+    const { from, to } = editor.state.selection;
+
+    // The element the caret is in decides what new paragraphs become, so a
     // handwritten line continues the writer's Action or Dialogue rather than
     // reverting to a default.
-    const elementType = editor.state.doc.resolve(target.from).parent.type.name;
+    const elementType = editor.state.doc.resolve(from).parent.type.name;
 
-    // Blank lines are the writer separating thoughts, not empty paragraphs to
-    // reproduce; a single line is inserted as text so it joins the sentence the
-    // caret was in instead of breaking the block in two.
-    const paragraphs = written.split(/\n\s*\n|\n/).map((p) => p.trim()).filter(Boolean);
-
-    const content = paragraphs.length <= 1
-      ? paragraphs[0] ?? ''
+    const content = paragraphs.length === 1
+      ? paragraphs[0]
       : paragraphs.map((p) => ({
         type: elementType,
         content: [{ type: 'text', text: p }],
@@ -292,36 +469,27 @@ const ScribbleInput: React.FC<ScribbleInputProps> = ({ editor, target, onClose }
 
     editor
       .chain()
-      .focus()
       // A range rather than a point: with text selected the writer is replacing
       // it, which is the revising half of what the Pencil is for.
-      .insertContentAt({ from: target.from, to: target.to }, content)
+      //
+      // No `.focus()`. Focusing the editor would take the Pencil out of the
+      // writing field on every insert, and this panel is built to be written in
+      // again straight away. `insertContentAt` leaves the selection after what
+      // it inserted, so the next insert carries on from there.
+      .insertContentAt({ from, to }, content)
       .run();
 
-    // Leave the writer looking at what they just wrote. The sheet can cover a
-    // different part of the script than the caret was in — and on a long script
-    // the insertion can be off screen entirely — so the caret is put after the
-    // new text and scrolled to in one transaction.
+    setText('');
     requestAnimationFrame(() => {
-      try {
-        const end = Math.min(
-          target.from + written.length + (paragraphs.length > 1 ? paragraphs.length * 2 : 0),
-          editor.state.doc.content.size,
-        );
-        const tr = editor.state.tr;
-        tr.setSelection(TextSelection.near(editor.state.doc.resolve(end)));
-        tr.scrollIntoView();
-        editor.view.dispatch(tr);
-      } catch {
-        /* the text is in; not scrolling to it is a small loss */
-      }
+      revealCaret();
+      // Back to the field, so the next sentence can be written without a tap.
+      areaRef.current?.focus();
+      trackSelection();
     });
+  }, [editor, text, revealCaret, trackSelection]);
 
-    onClose();
-  }, [editor, target, text, onClose]);
-
-  // Escape still cancels — it is a deliberate "I am done here", which is the
-  // bar the sheet holds everything else to.
+  // Escape closes — it is a deliberate "I am done here", which is the bar the
+  // panel holds everything else to.
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
       if (e.key === 'Escape') {
@@ -334,17 +502,32 @@ const ScribbleInput: React.FC<ScribbleInputProps> = ({ editor, target, onClose }
   }, [onClose]);
 
   return (
-    // No dismiss-on-backdrop. A palm, a sleeve or a stray Pencil tip landing
-    // outside the sheet used to throw away everything written in it; leaving
-    // only takes Cancel or Insert.
-    <div className="scribble-overlay">
-      <div className="scribble-sheet" role="dialog" aria-modal="true" aria-label="Handwriting input">
-        <div className="scribble-header">
-          <div className="scribble-header-row">
-            <span className="scribble-title">
-              Handwriting
-              {elementLabel && <span className="scribble-element">{elementLabel}</span>}
-            </span>
+    // No backdrop, and nothing dismisses this but the close button or Escape.
+    // The script behind it stays live on purpose: tapping a line there is how
+    // the writer moves where the next insert lands. (A palm, a sleeve or a
+    // stray Pencil tip landing outside used to throw away everything written
+    // in it.)
+    <div
+      className="scribble-panel"
+      ref={panelRef}
+      role="dialog"
+      aria-label="Handwriting input"
+      style={pos ? { left: pos.left, top: pos.top } : { visibility: 'hidden' }}
+    >
+      <div
+        className="scribble-header"
+        onPointerDown={onDragStart}
+        onPointerMove={onDragMove}
+        onPointerUp={onDragEnd}
+        onPointerCancel={onDragEnd}
+      >
+        <div className="scribble-header-row">
+          <span className="scribble-title">
+            <span className="scribble-grip" aria-hidden="true" />
+            Handwriting
+            {elementLabel && <span className="scribble-element">{elementLabel}</span>}
+          </span>
+          <div className="scribble-header-tools">
             <button
               type="button"
               className={`scribble-toggle ${keyboardOn ? 'is-on' : ''}`}
@@ -354,10 +537,31 @@ const ScribbleInput: React.FC<ScribbleInputProps> = ({ editor, target, onClose }
             >
               <FaKeyboard /> {keyboardOn ? 'Keyboard on' : 'Keyboard off'}
             </button>
+            <button
+              type="button"
+              className="scribble-toggle"
+              onClick={togglePreview}
+              aria-pressed={previewOn}
+              title={previewOn ? 'Hide the script preview' : 'Show the script preview'}
+            >
+              {previewOn ? <FaChevronUp /> : <FaChevronDown />} Preview
+            </button>
+            <button
+              type="button"
+              className="scribble-close"
+              onClick={onClose}
+              aria-label="Close handwriting"
+              title="Close handwriting"
+            >
+              <FaTimes />
+            </button>
           </div>
+        </div>
 
-          {/* The script either side of where this lands, in the editor's own
-              element styles and page metrics. */}
+        {/* The script either side of where this lands, in the editor's own
+            element styles and page metrics. It follows the caret: tap a
+            different line and this catches up. */}
+        {previewOn && (
           <div className="scribble-preview" ref={previewRef} aria-label="Where the text will go">
             <div className="scribble-preview-page screenplay-content" style={pageStyle}>
               {blocks.length === 0 ? (
@@ -367,7 +571,7 @@ const ScribbleInput: React.FC<ScribbleInputProps> = ({ editor, target, onClose }
                   key={b.key}
                   className={`screenplay-element ${elementClass(b.typeName)}${b.caretAt !== null ? ' is-target' : ''}`}
                 >
-                  {b.caretAt === null ? (b.text || ' ') : (
+                  {b.caretAt === null ? (b.text || ' ') : (
                     <>
                       {b.text.slice(0, b.caretAt)}
                       {b.replacing
@@ -380,9 +584,10 @@ const ScribbleInput: React.FC<ScribbleInputProps> = ({ editor, target, onClose }
               ))}
             </div>
           </div>
-        </div>
+        )}
+      </div>
 
-        <div className="scribble-area-wrap">
+      <div className="scribble-area-wrap">
         <textarea
           ref={areaRef}
           className="scribble-area"
@@ -403,53 +608,60 @@ const ScribbleInput: React.FC<ScribbleInputProps> = ({ editor, target, onClose }
           placeholder="Write here with your Apple Pencil"
         />
         {/* iPadOS paints no caret while the keyboard is down, which is how this
-            sheet is meant to be used, so the app draws one. */}
+            panel is meant to be used, so the app draws one. */}
         <TextareaCaret areaRef={areaRef} value={text} enabled={!keyboardOn} />
-        </div>
+      </div>
 
-        {/* The controls a Pencil cannot reach without a keyboard. iPadOS shows
-            its own palette for native fields, but not for a field inside a web
-            view, so the app has to supply the equivalents. */}
-        <div className="scribble-tools">
-          <button type="button" className="scribble-tool scribble-tool-key" onClick={() => replaceSelection('\n')}>
-            <FaLevelDownAlt style={{ transform: 'rotate(90deg)' }} /> Enter
-          </button>
-          <button
-            type="button"
-            className="scribble-tool scribble-tool-key"
-            onClick={() => replaceSelection('', true)}
-            disabled={text === ''}
-          >
-            <FaArrowLeft /> Backspace
-          </button>
-          <span className="scribble-tools-gap" />
-          <button type="button" className="scribble-tool" onClick={handleSelectAll} disabled={text === ''}>
-            <FaTextWidth /> Select All
-          </button>
-          <button type="button" className="scribble-tool" onClick={() => void handleCut()} disabled={!hasSelection}>
-            <FaCut /> Cut
-          </button>
-          <button type="button" className="scribble-tool" onClick={() => void handleCopy()} disabled={!hasSelection}>
-            <FaCopy /> Copy
-          </button>
-          <button type="button" className="scribble-tool" onClick={() => void handlePaste()}>
-            <FaPaste /> Paste
-          </button>
-        </div>
+      {/* The controls a Pencil cannot reach without a keyboard. iPadOS shows
+          its own palette for native fields, but not for a field inside a web
+          view, so the app has to supply the equivalents. */}
+      <div className="scribble-tools">
+        <button type="button" className="scribble-tool scribble-tool-key" onClick={() => replaceSelection('\n')}>
+          <FaLevelDownAlt style={{ transform: 'rotate(90deg)' }} /> Enter
+        </button>
+        <button
+          type="button"
+          className="scribble-tool scribble-tool-key"
+          onClick={() => replaceSelection('', true)}
+          disabled={text === ''}
+        >
+          <FaArrowLeft /> Backspace
+        </button>
+        <span className="scribble-tools-gap" />
+        <button type="button" className="scribble-tool" onClick={handleSelectAll} disabled={text === ''}>
+          <FaTextWidth /> Select All
+        </button>
+        <button type="button" className="scribble-tool" onClick={() => void handleCut()} disabled={!hasSelection}>
+          <FaCut /> Cut
+        </button>
+        <button type="button" className="scribble-tool" onClick={() => void handleCopy()} disabled={!hasSelection}>
+          <FaCopy /> Copy
+        </button>
+        <button type="button" className="scribble-tool" onClick={() => void handlePaste()}>
+          <FaPaste /> Paste
+        </button>
+      </div>
 
-        <div className="scribble-actions">
-          <button type="button" className="scribble-btn" onClick={onClose}>
-            Cancel
-          </button>
-          <button
-            type="button"
-            className="scribble-btn scribble-btn-primary"
-            onClick={handleInsert}
-            disabled={text.trim() === ''}
-          >
-            Insert
-          </button>
-        </div>
+      <div className="scribble-actions">
+        {/* Clear rather than Cancel: leaving is the close button's job now, and
+            what a writer wants after a misread word is the field empty, not the
+            panel gone. */}
+        <button
+          type="button"
+          className="scribble-btn"
+          onClick={() => { setText(''); areaRef.current?.focus(); }}
+          disabled={text === ''}
+        >
+          Clear
+        </button>
+        <button
+          type="button"
+          className="scribble-btn scribble-btn-primary"
+          onClick={handleInsert}
+          disabled={text.trim() === ''}
+        >
+          Insert
+        </button>
       </div>
     </div>
   );

--- a/frontend/src/components/SelectionHandles.tsx
+++ b/frontend/src/components/SelectionHandles.tsx
@@ -24,7 +24,7 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import type { Editor } from '@tiptap/react';
 import { TextSelection } from '@tiptap/pm/state';
-import { toPagePoint, type PagePoint } from '../utils/pageCoords';
+import { toPagePoint, toPageRect, type PagePoint, type PageRect } from '../utils/pageCoords';
 
 interface SelectionHandlesProps {
   editor: Editor | null;
@@ -49,32 +49,69 @@ interface Drag {
   dy: number;
 }
 
+/** Two readings of the same end, to the pixel. */
+const samePoint = (a: PagePoint, b: PagePoint) =>
+  a.left === b.left && a.top === b.top && a.height === b.height;
+
 const SelectionHandles: React.FC<SelectionHandlesProps> = ({ editor, enabled }) => {
   const [ends, setEnds] = useState<{ start: PagePoint; end: PagePoint } | null>(null);
+  /**
+   * The selection highlight, when the app has to draw it.
+   *
+   * iPadOS paints no highlight in a view without focus, so the moment the
+   * writer reaches for a menu the range they are about to act on disappears —
+   * leaving two handles marking the ends of nothing. The selection is still
+   * there and the command still applies to it, so what is missing is only the
+   * drawing of it. One band per line, from the range's own client rectangles.
+   */
+  const [bands, setBands] = useState<PageRect[] | null>(null);
   const dragRef = useRef<Drag | null>(null);
+  /** Mirrors dragRef into the render, purely to put the class on the handles. */
+  const [dragging, setDragging] = useState(false);
+  const frameRef = useRef<number | null>(null);
+  const settleRef = useRef<number | null>(null);
 
   const measure = useCallback(() => {
-    if (!editor || !enabled) { setEnds(null); return; }
+    /**
+     * Keep the object already in state when the reading has not changed.
+     * Every transaction re-measures and a drag dispatches one per pointer
+     * move, so handing React a fresh object each time re-rendered both
+     * handles on every event whether or not either had actually moved.
+     */
+    const apply = (next: { start: PagePoint; end: PagePoint } | null) =>
+      setEnds((prev) => {
+        if (next === null || prev === null) return prev === next ? prev : next;
+        return samePoint(prev.start, next.start) && samePoint(prev.end, next.end)
+          ? prev
+          : next;
+      });
+
+    if (!editor || !enabled) { apply(null); setBands(null); return; }
     try {
       const { state, view } = editor;
       // Read-only drafts have no selection to adjust.
-      if (!view.editable) { setEnds(null); return; }
+      if (!view.editable) { apply(null); return; }
 
       const sel = state.selection;
-      if (!(sel instanceof TextSelection) || sel.empty) { setEnds(null); return; }
+      if (!(sel instanceof TextSelection) || sel.empty) { apply(null); return; }
 
-      // Same reading as PencilCaret's: `view.hasFocus()` reports false in
-      // states where the editor plainly does hold focus. A drag keeps the
-      // handles up regardless — the pointer is captured by one of them, and
-      // wherever focus has gone it has not gone somewhere that ends the drag.
+      // Focus is deliberately not consulted, and neither is whether the
+      // browser is still painting the highlight.
+      //
+      // iPadOS stops drawing the highlight the moment the editor gives up
+      // focus — tapping a menu, the keyboard arriving or leaving — but the
+      // selection itself is untouched: it is still ProseMirror's selection,
+      // Cut still cuts it and a style still applies to it. Hiding the handles
+      // along with the highlight therefore took away the last thing on screen
+      // saying what those commands were about to act on, which is worse than
+      // the stale marker it was meant to fix. They are the stand-in for a
+      // selection UI the system is not drawing, exactly as PencilCaret is the
+      // stand-in for a caret it is not drawing, so they stay up for as long as
+      // there is a selection for them to mark.
       const dom = view.dom as HTMLElement;
-      const focused = document.activeElement === dom
-        || dom.contains(document.activeElement)
-        || dom.classList.contains('ProseMirror-focused');
-      if (!focused && !dragRef.current) { setEnds(null); return; }
 
       const page = dom.closest('.page') as HTMLElement | null;
-      if (!page) { setEnds(null); return; }
+      if (!page) { apply(null); return; }
 
       // Biased outwards, so each end is measured on the side the selection is
       // on: at a line wrap the same position sits at both the end of one line
@@ -82,45 +119,133 @@ const SelectionHandles: React.FC<SelectionHandlesProps> = ({ editor, enabled }) 
       // the wrong one.
       const start = toPagePoint(page, view.coordsAtPos(sel.from, 1));
       const end = toPagePoint(page, view.coordsAtPos(sel.to, -1));
-      if (!start || !end) { setEnds(null); return; }
-      setEnds({ start, end });
+      if (!start || !end) { apply(null); return; }
+      apply({ start, end });
+
+      const head = view.domAtPos(sel.from);
+      const tail = view.domAtPos(sel.to);
+      const range = document.createRange();
+      range.setStart(head.node, head.offset);
+      range.setEnd(tail.node, tail.offset);
+      const drawn: PageRect[] = [];
+      for (const box of Array.from(range.getClientRects())) {
+        if (box.width <= 0 || box.height <= 0) continue;
+        const band = toPageRect(page, box);
+        if (band) drawn.push(band);
+      }
+      setBands((prev) => {
+        if (!drawn.length) return prev === null ? prev : null;
+        if (prev && prev.length === drawn.length
+          && prev.every((b, i) => b.left === drawn[i].left && b.top === drawn[i].top
+            && b.width === drawn[i].width && b.height === drawn[i].height)) return prev;
+        return drawn;
+      });
     } catch {
       // coordsAtPos throws while the view is mid-update; the next tick re-reads.
-      setEnds(null);
+      apply(null);
+      setBands(null);
     }
   }, [editor, enabled]);
+
+  /**
+   * At most one reading per animation frame.
+   *
+   * A drag dispatches a new selection on every pointer move, and each dispatch
+   * fires both `transaction` and `selectionUpdate` — so measuring straight off
+   * the event took two full readings per move, four `coordsAtPos` calls and
+   * the page rectangle twice, each one forcing layout in the middle of the
+   * gesture it was meant to be keeping up with. A frame is as often as the
+   * handles can be repainted anyway; everything above that rate was work
+   * thrown away, and enough of it to be felt as the handle stuttering behind
+   * the finger rather than following it character by character (issue #108).
+   */
+  const schedule = useCallback(() => {
+    if (frameRef.current !== null) return;
+    frameRef.current = window.requestAnimationFrame(() => {
+      frameRef.current = null;
+      measure();
+    });
+  }, [measure]);
+
+  /**
+   * A reading taken after the current task has run to the end, for the first
+   * one: ProseMirror writes its DOM after the effect runs, so measuring inside
+   * it measures the layout the view is about to replace.
+   */
+  const scheduleSettled = useCallback(() => {
+    if (settleRef.current !== null) window.clearTimeout(settleRef.current);
+    settleRef.current = window.setTimeout(() => {
+      settleRef.current = null;
+      measure();
+    }, 0);
+  }, [measure]);
+
+  /**
+   * Suppress the system's own highlight for exactly as long as this component
+   * is drawing one, so the two can never both be on screen — the same bargain
+   * PencilCaret strikes with the system caret.
+   *
+   * Drawing ours only when the view lost focus was the obvious way to avoid
+   * the overlap, and it was wrong: the web view can hold focus and still stop
+   * painting a highlight, which is what the software keyboard arriving or
+   * leaving does. There is no signal from the outside for "is it painting one
+   * right now", so the question is removed instead — it never paints one here,
+   * and these bands are the highlight. Scoped to the script, so a selection in
+   * a search field or a dialog keeps the system's.
+   */
+  useEffect(() => {
+    if (!enabled) return;
+    document.body.classList.add('selection-bands-active');
+    return () => document.body.classList.remove('selection-bands-active');
+  }, [enabled]);
 
   useEffect(() => {
     if (!editor || !enabled) return;
 
-    editor.on('selectionUpdate', measure);
-    editor.on('transaction', measure);
-    editor.on('focus', measure);
-    editor.on('blur', measure);
+    editor.on('selectionUpdate', schedule);
+    editor.on('transaction', schedule);
+    editor.on('focus', schedule);
+    editor.on('blur', scheduleSettled);
+
+    // A drag that ends anywhere but on the handle — the pointer released over
+    // another element, or the handles unmounted under it — otherwise leaves
+    // the drag flag set for good, and every check that defers to a drag in
+    // progress stops doing its job.
+    const onGlobalRelease = () => {
+      if (!dragRef.current) return;
+      dragRef.current = null;
+      setDragging(false);
+      schedule();
+    };
+    window.addEventListener('pointerup', onGlobalRelease);
+    window.addEventListener('pointercancel', onGlobalRelease);
 
     const main = editor.view.dom.closest('.editor-main');
-    main?.addEventListener('scroll', measure, { passive: true });
-    window.addEventListener('resize', measure);
-    window.visualViewport?.addEventListener('resize', measure);
-    window.visualViewport?.addEventListener('scroll', measure);
+    main?.addEventListener('scroll', schedule, { passive: true });
+    const onViewportResize = () => { schedule(); scheduleSettled(); };
+    window.addEventListener('resize', onViewportResize);
+    window.visualViewport?.addEventListener('resize', onViewportResize);
+    window.visualViewport?.addEventListener('scroll', schedule);
 
-    // Take a first reading for a selection that already existed when this
-    // mounted — on the next tick rather than now, because ProseMirror writes
-    // its DOM after the effect runs, so measuring here measures the layout the
-    // view is about to replace.
-    const settle = window.setTimeout(measure, 0);
+    // A first reading for a selection that already existed when this mounted.
+    scheduleSettled();
     return () => {
-      window.clearTimeout(settle);
-      editor.off('selectionUpdate', measure);
-      editor.off('transaction', measure);
-      editor.off('focus', measure);
-      editor.off('blur', measure);
-      main?.removeEventListener('scroll', measure);
-      window.removeEventListener('resize', measure);
-      window.visualViewport?.removeEventListener('resize', measure);
-      window.visualViewport?.removeEventListener('scroll', measure);
+      if (frameRef.current !== null) window.cancelAnimationFrame(frameRef.current);
+      if (settleRef.current !== null) window.clearTimeout(settleRef.current);
+      frameRef.current = null;
+      settleRef.current = null;
+      editor.off('selectionUpdate', schedule);
+      editor.off('transaction', schedule);
+      editor.off('focus', schedule);
+      editor.off('blur', scheduleSettled);
+      window.removeEventListener('pointerup', onGlobalRelease);
+      window.removeEventListener('pointercancel', onGlobalRelease);
+      main?.removeEventListener('scroll', schedule);
+      window.removeEventListener('resize', onViewportResize);
+      window.visualViewport?.removeEventListener('resize', onViewportResize);
+      window.visualViewport?.removeEventListener('scroll', schedule);
     };
-  }, [editor, enabled, measure]);
+  }, [editor, enabled, schedule, scheduleSettled]);
 
   const handlePointerDown = (which: HandleEnd) => (e: React.PointerEvent<HTMLDivElement>) => {
     if (!editor) return;
@@ -140,6 +265,7 @@ const SelectionHandles: React.FC<SelectionHandlesProps> = ({ editor, enabled }) 
       dx: coords.left - e.clientX,
       dy: (coords.top + coords.bottom) / 2 - e.clientY,
     };
+    setDragging(true);
     e.currentTarget.setPointerCapture(e.pointerId);
   };
 
@@ -173,6 +299,7 @@ const SelectionHandles: React.FC<SelectionHandlesProps> = ({ editor, enabled }) 
   const endDrag = (e: React.PointerEvent<HTMLDivElement>) => {
     if (!dragRef.current) return;
     dragRef.current = null;
+    setDragging(false);
     if (e.currentTarget.hasPointerCapture(e.pointerId)) {
       e.currentTarget.releasePointerCapture(e.pointerId);
     }
@@ -184,7 +311,7 @@ const SelectionHandles: React.FC<SelectionHandlesProps> = ({ editor, enabled }) 
   const handle = (which: HandleEnd, point: PagePoint) => (
     <div
       key={which}
-      className={`selection-handle selection-handle-${which}`}
+      className={`selection-handle selection-handle-${which}${dragging ? ' is-dragging' : ''}`}
       aria-hidden="true"
       style={{ left: point.left, top: point.top, height: point.height }}
       onPointerDown={handlePointerDown(which)}
@@ -196,6 +323,14 @@ const SelectionHandles: React.FC<SelectionHandlesProps> = ({ editor, enabled }) 
 
   return (
     <>
+      {bands?.map((b, i) => (
+        <div
+          key={`band-${i}`}
+          className="selection-band"
+          aria-hidden="true"
+          style={{ left: b.left, top: b.top, width: b.width, height: b.height }}
+        />
+      ))}
       {handle('start', ends.start)}
       {handle('end', ends.end)}
     </>

--- a/frontend/src/components/SelectionHandles.tsx
+++ b/frontend/src/components/SelectionHandles.tsx
@@ -1,0 +1,205 @@
+/**
+ * Draggable selection handles, for the same reason PencilCaret exists.
+ *
+ * iPadOS does not put its own selection grabbers on a range selected inside
+ * this web view. The range highlights, and that is all: to move either end of
+ * it by a word the writer has to throw the selection away and make it again
+ * (issue #108). Every other text field on the device shows a handle at each
+ * end that can be dragged to widen or narrow the selection, and a screenplay
+ * editor is exactly where that matters.
+ *
+ * So the app draws them. Deliberately narrow, the way the caret is:
+ *
+ *   - the iOS web view only, where the system provides none. Android's web
+ *     view draws its own, and so does Safari; a second pair on top of those
+ *     would be two handles per end, both live.
+ *   - text ranges only. A node selection — a tapped image — is not a range
+ *     with ends to drag.
+ *
+ * Like the caret, these are ordinary children of `.page` rather than a portal
+ * into `.ProseMirror`: ProseMirror owns the DOM inside its own element and
+ * replaces those children as the document changes, so React later fails to
+ * find a node it put there and the view dies with `NotFoundError`.
+ */
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import type { Editor } from '@tiptap/react';
+import { TextSelection } from '@tiptap/pm/state';
+import { toPagePoint, type PagePoint } from '../utils/pageCoords';
+
+interface SelectionHandlesProps {
+  editor: Editor | null;
+  /** The iOS web view. Everywhere else the system draws its own. */
+  enabled: boolean;
+}
+
+/** Which end of the range a handle belongs to, and which one is being dragged. */
+type HandleEnd = 'start' | 'end';
+
+interface Drag {
+  /** The end left where it was; the drag moves the other one against it. */
+  anchor: number;
+  /**
+   * Pointer-to-text offset, captured when the drag began. The knob sits clear
+   * of the text so a finger does not cover it, so the position under the
+   * finger is not the position being moved. Measured rather than hard-coded,
+   * so wherever on the handle the writer grabbed it, the text end stays put
+   * under that grip instead of jumping to meet the finger.
+   */
+  dx: number;
+  dy: number;
+}
+
+const SelectionHandles: React.FC<SelectionHandlesProps> = ({ editor, enabled }) => {
+  const [ends, setEnds] = useState<{ start: PagePoint; end: PagePoint } | null>(null);
+  const dragRef = useRef<Drag | null>(null);
+
+  const measure = useCallback(() => {
+    if (!editor || !enabled) { setEnds(null); return; }
+    try {
+      const { state, view } = editor;
+      // Read-only drafts have no selection to adjust.
+      if (!view.editable) { setEnds(null); return; }
+
+      const sel = state.selection;
+      if (!(sel instanceof TextSelection) || sel.empty) { setEnds(null); return; }
+
+      // Same reading as PencilCaret's: `view.hasFocus()` reports false in
+      // states where the editor plainly does hold focus. A drag keeps the
+      // handles up regardless — the pointer is captured by one of them, and
+      // wherever focus has gone it has not gone somewhere that ends the drag.
+      const dom = view.dom as HTMLElement;
+      const focused = document.activeElement === dom
+        || dom.contains(document.activeElement)
+        || dom.classList.contains('ProseMirror-focused');
+      if (!focused && !dragRef.current) { setEnds(null); return; }
+
+      const page = dom.closest('.page') as HTMLElement | null;
+      if (!page) { setEnds(null); return; }
+
+      // Biased outwards, so each end is measured on the side the selection is
+      // on: at a line wrap the same position sits at both the end of one line
+      // and the start of the next, and an unbiased reading puts the handle on
+      // the wrong one.
+      const start = toPagePoint(page, view.coordsAtPos(sel.from, 1));
+      const end = toPagePoint(page, view.coordsAtPos(sel.to, -1));
+      if (!start || !end) { setEnds(null); return; }
+      setEnds({ start, end });
+    } catch {
+      // coordsAtPos throws while the view is mid-update; the next tick re-reads.
+      setEnds(null);
+    }
+  }, [editor, enabled]);
+
+  useEffect(() => {
+    if (!editor || !enabled) return;
+
+    editor.on('selectionUpdate', measure);
+    editor.on('transaction', measure);
+    editor.on('focus', measure);
+    editor.on('blur', measure);
+
+    const main = editor.view.dom.closest('.editor-main');
+    main?.addEventListener('scroll', measure, { passive: true });
+    window.addEventListener('resize', measure);
+    window.visualViewport?.addEventListener('resize', measure);
+    window.visualViewport?.addEventListener('scroll', measure);
+
+    // Take a first reading for a selection that already existed when this
+    // mounted — on the next tick rather than now, because ProseMirror writes
+    // its DOM after the effect runs, so measuring here measures the layout the
+    // view is about to replace.
+    const settle = window.setTimeout(measure, 0);
+    return () => {
+      window.clearTimeout(settle);
+      editor.off('selectionUpdate', measure);
+      editor.off('transaction', measure);
+      editor.off('focus', measure);
+      editor.off('blur', measure);
+      main?.removeEventListener('scroll', measure);
+      window.removeEventListener('resize', measure);
+      window.visualViewport?.removeEventListener('resize', measure);
+      window.visualViewport?.removeEventListener('scroll', measure);
+    };
+  }, [editor, enabled, measure]);
+
+  const handlePointerDown = (which: HandleEnd) => (e: React.PointerEvent<HTMLDivElement>) => {
+    if (!editor) return;
+    const sel = editor.state.selection;
+    if (sel.empty) return;
+
+    // Nothing about a handle is a click on the document: preventDefault keeps
+    // the tap from moving focus out of the editor and collapsing the very
+    // selection being adjusted.
+    e.preventDefault();
+    e.stopPropagation();
+
+    const moving = which === 'start' ? sel.from : sel.to;
+    const coords = editor.view.coordsAtPos(moving, which === 'start' ? 1 : -1);
+    dragRef.current = {
+      anchor: which === 'start' ? sel.to : sel.from,
+      dx: coords.left - e.clientX,
+      dy: (coords.top + coords.bottom) / 2 - e.clientY,
+    };
+    e.currentTarget.setPointerCapture(e.pointerId);
+  };
+
+  const handlePointerMove = (e: React.PointerEvent<HTMLDivElement>) => {
+    const drag = dragRef.current;
+    if (!drag || !editor) return;
+    e.preventDefault();
+
+    const { state, view } = editor;
+    const at = view.posAtCoords({ left: e.clientX + drag.dx, top: e.clientY + drag.dy });
+    if (!at) return;
+
+    try {
+      // `between` is what ProseMirror uses for a mouse drag: it settles on the
+      // nearest position that can actually hold a text selection, so a finger
+      // over a page margin or a page break does not throw the range away. It
+      // also lets the moving end cross the fixed one, which is what iPadOS
+      // does — past the crossing, the handle under the finger is the other one.
+      const next = TextSelection.between(state.doc.resolve(drag.anchor), state.doc.resolve(at.pos));
+      // A collapsed range would unmount the handles mid-drag, taking the
+      // pointer capture with them and stranding the gesture. The two ends stay
+      // at least one position apart instead.
+      if (next.empty || next.eq(state.selection)) return;
+      view.dispatch(state.tr.setSelection(next));
+    } catch {
+      // The anchor can fall outside a document that changed under the drag —
+      // a collaborator's edit. Nothing to move it to; the next move re-reads.
+    }
+  };
+
+  const endDrag = (e: React.PointerEvent<HTMLDivElement>) => {
+    if (!dragRef.current) return;
+    dragRef.current = null;
+    if (e.currentTarget.hasPointerCapture(e.pointerId)) {
+      e.currentTarget.releasePointerCapture(e.pointerId);
+    }
+    measure();
+  };
+
+  if (!ends) return null;
+
+  const handle = (which: HandleEnd, point: PagePoint) => (
+    <div
+      key={which}
+      className={`selection-handle selection-handle-${which}`}
+      aria-hidden="true"
+      style={{ left: point.left, top: point.top, height: point.height }}
+      onPointerDown={handlePointerDown(which)}
+      onPointerMove={handlePointerMove}
+      onPointerUp={endDrag}
+      onPointerCancel={endDrag}
+    />
+  );
+
+  return (
+    <>
+      {handle('start', ends.start)}
+      {handle('end', ends.end)}
+    </>
+  );
+};
+
+export default SelectionHandles;

--- a/frontend/src/services/platform.ts
+++ b/frontend/src/services/platform.ts
@@ -104,6 +104,19 @@ export function getOS(): 'macos' | 'windows' | 'linux' | 'android' | 'ios' | 'un
 }
 
 /**
+ * Whether the app has to draw its own text-selection handles (issue #108).
+ *
+ * iPadOS puts no selection grabbers on a range selected inside this web view:
+ * the text highlights and that is all, so neither end of the selection can be
+ * nudged without starting again. Every other web view on the device is left
+ * alone — Android's draws its own, and so does Safari, and a second pair drawn
+ * over those would be two live handles at each end.
+ */
+export function needsSelectionHandles(): boolean {
+  return isTauri() && getOS() === 'ios';
+}
+
+/**
  * Whether this device is one an Apple Pencil can be used with — an iPad.
  *
  * iPhone and iPod run the same OS and report the same way, but no Pencil pairs

--- a/frontend/src/styles/screenplay.css
+++ b/frontend/src/styles/screenplay.css
@@ -9484,7 +9484,16 @@ body.selection-bands-active .page .ProseMirror::selection { background: transpar
      leave the script either side of it readable. */
   width: min(720px, calc(100vw - 16px));
   max-height: calc(var(--vv-height, 100dvh) - 16px);
-  background: var(--fd-dropdown-bg);
+  /* Resizable, so a width and height set by the writer arrive as inline
+     styles and have to be allowed to win over the defaults above. */
+  min-width: 300px;
+  min-height: 240px;
+  /* See-through by however much the writer asked for. The panel sits over the
+     page it is being used to edit, and how much of that page has to stay
+     readable underneath depends on where they have put it. */
+  background: color-mix(in srgb, var(--fd-dropdown-bg)
+    calc(var(--scribble-panel-alpha, 1) * 100%), transparent);
+  backdrop-filter: blur(2px);
   border: 1px solid var(--fd-border);
   border-radius: 14px;
   box-shadow: 0 12px 40px rgba(0, 0, 0, 0.45);
@@ -9493,7 +9502,7 @@ body.selection-bands-active .page .ProseMirror::selection { background: transpar
   overflow: hidden;
 }
 [data-theme="light"] .scribble-panel {
-  background: #fff;
+  background: color-mix(in srgb, #fff calc(var(--scribble-panel-alpha, 1) * 100%), transparent);
   box-shadow: 0 12px 40px rgba(0, 0, 0, 0.22);
 }
 .scribble-header {
@@ -9612,8 +9621,8 @@ body.selection-bands-active .page .ProseMirror::selection { background: transpar
 /* The field and its drawn caret share a positioned box. When the app draws the
    caret the native one is off, so there is only ever one. */
 .scribble-area-wrap { position: relative; display: flex; flex: 1 1 auto; min-height: 0; }
-.scribble-area-wrap .scribble-caret { color: var(--fd-text); z-index: 2; }
-.scribble-area { caret-color: var(--fd-accent, #3b82f6); }
+.scribble-area-wrap .scribble-caret { color: var(--scribble-ink, var(--fd-text)); z-index: 2; }
+.scribble-area { caret-color: var(--scribble-ink, var(--fd-accent, #3b82f6)); }
 .scribble-area-wrap:has(.scribble-caret) .scribble-area { caret-color: transparent; }
 .scribble-area:focus {
   outline: 2px solid var(--fd-accent, #3b82f6);
@@ -13026,3 +13035,73 @@ body.selection-bands-active .page .ProseMirror::selection { background: transpar
 }
 .shortcut-clear:hover:not(:disabled) { color: var(--fd-text); }
 .shortcut-clear:disabled { opacity: .4; cursor: default; }
+
+/* ── Handwriting panel: resize, transparency, ink, narrow widths ────────── */
+
+/* The writing field, see-through by its own amount so the line of script the
+   writer is about to add to can be read straight through where they write it.
+   Its own control rather than the panel's: the chrome and the field want very
+   different amounts of it. */
+.scribble-area {
+  background: color-mix(in srgb, var(--fd-input-bg, rgba(255, 255, 255, 0.06))
+    calc(var(--scribble-area-alpha, 1) * 100%), transparent);
+  color: var(--scribble-ink, var(--fd-text));
+}
+
+/* Grab the corner to resize. Sized for a fingertip rather than a pointer, and
+   `touch-action: none` so the drag does not scroll the script underneath. */
+.scribble-resize {
+  position: absolute;
+  right: 0;
+  bottom: 0;
+  width: 26px;
+  height: 26px;
+  cursor: nwse-resize;
+  touch-action: none;
+  z-index: 2;
+}
+.scribble-resize::after {
+  content: '';
+  position: absolute;
+  right: 5px;
+  bottom: 5px;
+  width: 11px;
+  height: 11px;
+  border-right: 2px solid var(--fd-text-dim, #8a8a8a);
+  border-bottom: 2px solid var(--fd-text-dim, #8a8a8a);
+  border-bottom-right-radius: 3px;
+  opacity: 0.7;
+}
+
+/* Narrow: the buttons keep their icons and drop their words. Their accessible
+   names stay on the button, so nothing is lost to a screen reader. */
+.scribble-panel.is-compact .scribble-tool-label { display: none; }
+.scribble-panel.is-compact .scribble-tool { padding-left: 10px; padding-right: 10px; }
+.scribble-panel.is-compact .scribble-header { padding: 8px 10px 6px; }
+
+.scribble-settings {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 10px 18px;
+  padding: 8px 2px 2px;
+  border-top: 1px solid var(--fd-border);
+  /* Its own controls, not the header's drag surface. */
+  cursor: default;
+  touch-action: auto;
+}
+.scribble-setting { display: flex; align-items: center; gap: 8px; font-size: 12px; color: var(--fd-text-dim, #9aa0a6); }
+.scribble-setting input[type="range"] { width: 108px; accent-color: var(--fd-accent, #3b82f6); }
+.scribble-ink-row { display: flex; gap: 6px; }
+.scribble-ink {
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  border: 2px solid transparent;
+  box-shadow: 0 0 0 1px var(--fd-border);
+  padding: 0;
+  cursor: pointer;
+}
+.scribble-ink.is-default { background: linear-gradient(135deg, #d4d4d4 50%, #6b6b6b 50%); }
+.scribble-ink.is-on { border-color: var(--fd-accent, #3b82f6); }
+.scribble-close.is-on { color: var(--fd-accent, #3b82f6); }

--- a/frontend/src/styles/screenplay.css
+++ b/frontend/src/styles/screenplay.css
@@ -7203,6 +7203,52 @@ body.pencil-caret-active .page .ProseMirror { caret-color: transparent; }
   .pencil-caret { animation: none; }
 }
 
+/* Draggable selection handles (see SelectionHandles.tsx). iPadOS draws none of
+   its own inside this web view, so the app draws them, in the same blue as the
+   selection highlight above so the three read as one thing.
+
+   Absolute inside .page, like the caret, so they scroll and scale with the
+   text. Unlike the caret they are not inert: each one is the drag target, and
+   `touch-action: none` is what stops a drag along a handle from scrolling the
+   page out from under the gesture instead of moving the selection. */
+.selection-handle {
+  position: absolute;
+  width: 2px;
+  margin-left: -1px;
+  background: #338fff;
+  z-index: 41;
+  touch-action: none;
+}
+
+/* The knob. Clear of the text — above the start, below the end — so a finger
+   on it is not covering the character the handle is pointing at, which is the
+   character the writer is trying to see. */
+.selection-handle::before {
+  content: '';
+  position: absolute;
+  left: 50%;
+  width: 12px;
+  height: 12px;
+  margin-left: -6px;
+  border-radius: 50%;
+  background: inherit;
+}
+.selection-handle-start::before { top: -11px; }
+.selection-handle-end::before { bottom: -11px; }
+
+/* A finger-sized target around a 2px line. Invisible, and wider than the
+   handle in every direction so the knob can be grabbed from slightly off it —
+   the whole point of a handle is that it is caught first time. */
+.selection-handle::after {
+  content: '';
+  position: absolute;
+  left: 50%;
+  width: 44px;
+  margin-left: -22px;
+  top: -24px;
+  bottom: -24px;
+}
+
 /* History mode: visual feedback on the editor area */
 .app-container.history-mode .editor-main {
   background: repeating-linear-gradient(

--- a/frontend/src/styles/screenplay.css
+++ b/frontend/src/styles/screenplay.css
@@ -7220,6 +7220,45 @@ body.pencil-caret-active .page .ProseMirror { caret-color: transparent; }
   touch-action: none;
 }
 
+/* Invisible to hit-testing for as long as a drag is running.
+ *
+ * The drag asks ProseMirror what position is under the finger, and
+ * `posAtCoords` answers by hit-testing that point: `elementFromPoint`, then a
+ * check that the result is inside `.ProseMirror`. These handles are children
+ * of `.page` rather than of the editor — they have to be, ProseMirror replaces
+ * its own children — so a probe that lands on one fails that check and falls
+ * back to `posFromElement`, which measures block rectangles rather than
+ * characters. The probe lands on one constantly: the handle is drawn at
+ * exactly the position being probed, and its grab target is 44px wide. That
+ * coarse fallback is what moved the selection two characters at a time
+ * (issue #108).
+ *
+ * Pointer capture is unaffected — a captured pointer is delivered to its
+ * capture target ahead of any hit test — so the handle keeps receiving the
+ * move and up events that drive the drag. Both handles are neutralised, not
+ * just the one being dragged, because the two ends pass close to each other. */
+.selection-handle.is-dragging { pointer-events: none; }
+
+/* No system highlight while SelectionHandles is drawing its own, so the script
+   never shows two over the same words. The caret has the same arrangement just
+   above. Only inside the page — a search field or a dialog keeps its own. */
+body.selection-bands-active .page .ProseMirror ::selection,
+body.selection-bands-active .page .ProseMirror::selection { background: transparent; }
+
+/* The stand-in selection highlight (see SelectionHandles.tsx). Drawn only when
+   the web view has no focus and so paints none of its own. Behind the text and
+   inert: `posAtCoords` hit-tests the point under the finger during a handle
+   drag, and anything catching that hit test outside .ProseMirror sends the
+   lookup down a coarse fallback path — which is what made dragging jump two
+   characters at a time in the first place. */
+.selection-band {
+  position: absolute;
+  background: rgba(51, 143, 255, 0.30);
+  pointer-events: none;
+  z-index: 39;
+  border-radius: 1px;
+}
+
 /* The knob. Clear of the text — above the start, below the end — so a finger
    on it is not covering the character the handle is pointing at, which is the
    character the writer is trying to see. */

--- a/frontend/src/styles/screenplay.css
+++ b/frontend/src/styles/screenplay.css
@@ -9430,42 +9430,65 @@ body.pencil-caret-active .page .ProseMirror { caret-color: transparent; }
    cramped, destructive behaviour in the editor was a symptom of there being
    almost none mid-script (issue #90). Nothing follows the caret in here, so
    nothing can be overwritten. */
-.scribble-overlay {
+/* A floating panel, not a modal sheet. There is no backdrop on purpose: the
+   script behind stays live, and tapping a line in it is how the writer moves
+   where the next insert lands without closing anything (issue #90). It is
+   dragged by its header, because only the writer knows which part of the page
+   it must not cover. */
+.scribble-panel {
   position: fixed;
-  inset: 0;
+  /* Placed by the component, which measures it and keeps it on screen. */
+  left: 0;
+  top: 0;
   z-index: 3600;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 16px;
-  background: rgba(0, 0, 0, 0.45);
-}
-.scribble-sheet {
-  /* Bigger than it was: this is a writing surface, not a prompt, and a Pencil
-     needs room to form letters at a natural size. */
-  width: min(980px, 100%);
-  max-height: calc(var(--vv-height, 100dvh) - 32px);
+  /* Wide enough to write a line of dialogue at hand size, narrow enough to
+     leave the script either side of it readable. */
+  width: min(720px, calc(100vw - 16px));
+  max-height: calc(var(--vv-height, 100dvh) - 16px);
   background: var(--fd-dropdown-bg);
   border: 1px solid var(--fd-border);
   border-radius: 14px;
-  box-shadow: 0 12px 40px rgba(0, 0, 0, 0.35);
+  box-shadow: 0 12px 40px rgba(0, 0, 0, 0.45);
   display: flex;
   flex-direction: column;
   overflow: hidden;
 }
-[data-theme="light"] .scribble-sheet {
+[data-theme="light"] .scribble-panel {
   background: #fff;
-  box-shadow: 0 12px 40px rgba(0, 0, 0, 0.15);
+  box-shadow: 0 12px 40px rgba(0, 0, 0, 0.22);
 }
 .scribble-header {
-  padding: 14px 18px 10px;
+  padding: 10px 14px 8px;
   display: flex;
   flex-direction: column;
   gap: 8px;
+  /* The drag handle. `touch-action: none` so a Pencil or a fingertip dragging
+     the panel does not scroll the script underneath at the same time. */
+  cursor: grab;
+  touch-action: none;
+  border-bottom: 1px solid var(--fd-border);
 }
+.scribble-header:active { cursor: grabbing; }
 .scribble-header-row {
   display: flex; align-items: center; justify-content: space-between; gap: 12px;
 }
+.scribble-header-tools { display: flex; align-items: center; gap: 8px; }
+.scribble-title { display: inline-flex; align-items: center; font-weight: 600; }
+/* The grip says "this moves" without a line of instructions. */
+.scribble-grip {
+  width: 18px; height: 10px; margin-right: 9px;
+  background-image: radial-gradient(currentColor 1.2px, transparent 1.3px);
+  background-size: 6px 5px;
+  color: var(--fd-text-muted);
+  opacity: .8;
+}
+.scribble-close {
+  display: inline-flex; align-items: center; justify-content: center;
+  width: 34px; height: 34px;
+  background: none; border: 1px solid var(--fd-border); border-radius: 8px;
+  color: var(--fd-text-muted); cursor: pointer;
+}
+.scribble-close:hover { color: var(--fd-text); background: var(--fd-menu-hover); }
 .scribble-toggle {
   display: inline-flex; align-items: center; gap: 7px;
   min-height: 34px; padding: 0 12px;
@@ -9482,7 +9505,9 @@ body.pencil-caret-active .page .ProseMirror { caret-color: transparent; }
    Character column. The page is rendered at full width and scaled down, because
    element indents are absolute inches and do not survive being re-measured. */
 .scribble-preview {
-  max-height: 210px;
+  /* Shorter than the modal sheet's: the panel sits over the script, so every
+     pixel it takes is a pixel of the page the writer cannot see. */
+  max-height: 150px;
   overflow: auto;
   padding: 10px;
   background: var(--fd-bg);
@@ -9529,10 +9554,11 @@ body.pencil-caret-active .page .ProseMirror { caret-color: transparent; }
   text-decoration: line-through;
 }
 .scribble-area {
-  margin: 0 18px;
-  /* Tall enough to write several lines at a natural hand size, and it grows
-     with the viewport rather than being pinned to a phone-sized box. */
-  min-height: max(300px, 40vh);
+  margin: 10px 14px 0;
+  /* Still tall enough to write two or three lines at a natural hand size —
+     which is what the Pencil needs and what the page could not give it — while
+     leaving most of the script visible behind the panel. */
+  min-height: max(190px, 26vh);
   flex: 1 1 auto;
   resize: none;
   padding: 14px 16px;
@@ -9556,7 +9582,7 @@ body.pencil-caret-active .page .ProseMirror { caret-color: transparent; }
 }
 .scribble-tools {
   display: flex; flex-wrap: wrap; gap: 8px;
-  padding: 10px 18px 0;
+  padding: 10px 14px 0;
 }
 .scribble-tool {
   display: inline-flex; align-items: center; gap: 6px;
@@ -9573,7 +9599,7 @@ body.pencil-caret-active .page .ProseMirror { caret-color: transparent; }
   display: flex;
   justify-content: flex-end;
   gap: 10px;
-  padding: 14px 18px;
+  padding: 10px 14px 12px;
 }
 .scribble-btn {
   /* A 44pt target: this is reached with a Pencil tip or a fingertip. */

--- a/frontend/src/utils/handwriting.test.ts
+++ b/frontend/src/utils/handwriting.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest';
+import {
+  clampPanelPosition,
+  defaultPanelPosition,
+  splitHandwriting,
+  PANEL_MARGIN,
+} from './handwriting';
+
+const PANEL = { width: 700, height: 400 };
+const IPAD = { width: 1180, height: 820 };
+
+describe('clampPanelPosition', () => {
+  it('leaves a panel that is already on screen where it is', () => {
+    expect(clampPanelPosition({ left: 200, top: 100 }, PANEL, IPAD))
+      .toEqual({ left: 200, top: 100 });
+  });
+
+  it('pulls a panel dragged off the right or the bottom back into view', () => {
+    expect(clampPanelPosition({ left: 2000, top: 2000 }, PANEL, IPAD))
+      .toEqual({ left: 1180 - 700 - PANEL_MARGIN, top: 820 - 400 - PANEL_MARGIN });
+  });
+
+  it('pulls a panel dragged off the left or the top back into view', () => {
+    expect(clampPanelPosition({ left: -500, top: -500 }, PANEL, IPAD))
+      .toEqual({ left: PANEL_MARGIN, top: PANEL_MARGIN });
+  });
+
+  it('keeps the controls reachable when the panel is larger than the viewport', () => {
+    // The keyboard is up and the panel is taller than what is left: the header
+    // is the end with the drag handle and the close button, so it stays put.
+    const squashed = { width: 400, height: 300 };
+    expect(clampPanelPosition({ left: 100, top: 100 }, PANEL, squashed))
+      .toEqual({ left: PANEL_MARGIN, top: PANEL_MARGIN });
+  });
+});
+
+describe('defaultPanelPosition', () => {
+  it('opens centred across the foot of the window', () => {
+    const pos = defaultPanelPosition(PANEL, IPAD);
+    expect(pos.left).toBe(Math.round((1180 - 700) / 2));
+    expect(pos.top).toBe(820 - 400 - PANEL_MARGIN);
+  });
+
+  it('is on screen even when the panel does not fit', () => {
+    expect(defaultPanelPosition(PANEL, { width: 500, height: 300 }))
+      .toEqual({ left: PANEL_MARGIN, top: PANEL_MARGIN });
+  });
+});
+
+describe('splitHandwriting', () => {
+  it('returns a single line as one paragraph', () => {
+    expect(splitHandwriting('He crosses to the window.'))
+      .toEqual(['He crosses to the window.']);
+  });
+
+  it('splits lines into paragraphs', () => {
+    expect(splitHandwriting('First line\nSecond line'))
+      .toEqual(['First line', 'Second line']);
+  });
+
+  it('collapses blank lines rather than reproducing them', () => {
+    expect(splitHandwriting('First\n\n\nSecond'))
+      .toEqual(['First', 'Second']);
+  });
+
+  it('trims the stray leading space handwriting recognition adds', () => {
+    expect(splitHandwriting('  He turns.  \n  She does not.  '))
+      .toEqual(['He turns.', 'She does not.']);
+  });
+
+  it('has nothing to insert for whitespace alone', () => {
+    expect(splitHandwriting('   \n  \n')).toEqual([]);
+  });
+});

--- a/frontend/src/utils/handwriting.test.ts
+++ b/frontend/src/utils/handwriting.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import {
   clampPanelPosition,
   defaultPanelPosition,
+  joinHandwriting,
   splitHandwriting,
   PANEL_MARGIN,
 } from './handwriting';
@@ -70,5 +71,43 @@ describe('splitHandwriting', () => {
 
   it('has nothing to insert for whitespace alone', () => {
     expect(splitHandwriting('   \n  \n')).toEqual([]);
+  });
+});
+
+describe('joinHandwriting', () => {
+  it('spaces an insert off the word before it', () => {
+    // The reported case: "(CONTINUOUS)" written at the end of a scene heading.
+    expect(joinHandwriting('(CONTINUOUS)', 'Y', '')).toBe(' (CONTINUOUS)');
+  });
+
+  it('spaces both sides when it lands between two words', () => {
+    expect(joinHandwriting('very', 'e', 'q')).toBe(' very ');
+  });
+
+  it('adds nothing at the start or the end of a block', () => {
+    expect(joinHandwriting('She turns.', '', '')).toBe('She turns.');
+  });
+
+  it('leaves an existing space alone rather than doubling it', () => {
+    expect(joinHandwriting('quiet', ' ', ' ')).toBe('quiet');
+  });
+
+  it('does not push punctuation away from the word it belongs to', () => {
+    // Writing a word in front of a comma, and a comma in front of a word.
+    expect(joinHandwriting('slowly', 'n', ',')).toBe(' slowly');
+    expect(joinHandwriting(', slowly', 'n', '')).toBe(', slowly');
+  });
+
+  it('keeps brackets and quotes tight to what they open', () => {
+    expect(joinHandwriting('beat', '(', ')')).toBe('beat');
+    expect(joinHandwriting('(beat)', 's', '')).toBe(' (beat)');
+  });
+
+  it('does not put a space after text that ends in an opening bracket', () => {
+    expect(joinHandwriting('(', 'e', 'b')).toBe(' (');
+  });
+
+  it('has nothing to space when there is nothing to insert', () => {
+    expect(joinHandwriting('', 'e', 'b')).toBe('');
   });
 });

--- a/frontend/src/utils/handwriting.ts
+++ b/frontend/src/utils/handwriting.ts
@@ -1,17 +1,85 @@
 /**
- * Asking for the handwriting sheet, from anywhere.
+ * The handwriting panel: how it is asked for, and the arithmetic it floats by.
  *
- * A window event rather than a prop, because the two places that offer it — the
- * Edit menu and the touch context menu — are neither of them parents of the
- * editor that owns the sheet. It follows the pattern `opendraft:auth-required`
- * already set.
+ * The request is a window event rather than a prop, because the two places that
+ * offer it — the Edit menu and the touch context menu — are neither of them
+ * parents of the editor that owns the panel. It follows the pattern
+ * `opendraft:auth-required` already set.
  *
  * Its own module rather than a second export from `ScribbleInput`: a file that
- * exports both a component and a constant loses fast refresh.
+ * exports both a component and a constant loses fast refresh. The placement and
+ * paragraph rules live here too, where they can be tested without a document,
+ * a Pencil or an iPad.
  */
 export const HANDWRITING_EVENT = 'opendraft:handwriting';
 
-/** Ask the editor to open the handwriting sheet at the current selection. */
+/** Ask the editor to open the handwriting panel at the current selection. */
 export function requestHandwriting(): void {
   window.dispatchEvent(new CustomEvent(HANDWRITING_EVENT));
+}
+
+export interface PanelSize { width: number; height: number }
+export interface PanelPos { left: number; top: number }
+export interface Viewport { width: number; height: number }
+
+/** Breathing room between the panel and the edge of the screen. */
+export const PANEL_MARGIN = 8;
+
+/**
+ * Keep the panel on screen.
+ *
+ * It is dragged with a Pencil or a fingertip, the window rotates, and the
+ * software keyboard changes the visible height under it — any of which can
+ * leave a freely positioned panel with its header, and so its drag handle and
+ * its close button, past the edge with no way back. The whole panel is kept
+ * inside the viewport while it fits; when it does not fit — a phone in
+ * landscape, an iPad with the keyboard up — the top-left corner wins, because
+ * that is the end the controls are on.
+ */
+export function clampPanelPosition(
+  pos: PanelPos,
+  size: PanelSize,
+  viewport: Viewport,
+  margin: number = PANEL_MARGIN,
+): PanelPos {
+  const maxLeft = viewport.width - size.width - margin;
+  const maxTop = viewport.height - size.height - margin;
+  return {
+    left: Math.round(Math.min(Math.max(pos.left, margin), Math.max(margin, maxLeft))),
+    top: Math.round(Math.min(Math.max(pos.top, margin), Math.max(margin, maxTop))),
+  };
+}
+
+/**
+ * Where the panel opens when the writer has never moved it: centred across the
+ * foot of the window. Low, because what it must not cover is the line being
+ * written into, and the script runs down from the top; centred, because the
+ * iPad is held either way up.
+ */
+export function defaultPanelPosition(
+  size: PanelSize,
+  viewport: Viewport,
+  margin: number = PANEL_MARGIN,
+): PanelPos {
+  return clampPanelPosition(
+    {
+      left: Math.round((viewport.width - size.width) / 2),
+      top: Math.round(viewport.height - size.height - margin),
+    },
+    size,
+    viewport,
+    margin,
+  );
+}
+
+/**
+ * What was written, as paragraphs.
+ *
+ * Blank lines are the writer separating thoughts rather than empty paragraphs
+ * to reproduce, so runs of them collapse. A single line comes back as one
+ * entry, which the caller inserts as text so it joins the sentence the caret
+ * was in instead of breaking the block in two.
+ */
+export function splitHandwriting(text: string): string[] {
+  return text.split(/\n\s*\n|\n/).map((p) => p.trim()).filter(Boolean);
 }

--- a/frontend/src/utils/handwriting.ts
+++ b/frontend/src/utils/handwriting.ts
@@ -83,3 +83,47 @@ export function defaultPanelPosition(
 export function splitHandwriting(text: string): string[] {
   return text.split(/\n\s*\n|\n/).map((p) => p.trim()).filter(Boolean);
 }
+
+/**
+ * Characters that hug the word before them: an insert starting with one of
+ * these wants no space in front of it, or a comma ends up adrift.
+ */
+const ATTACHES_LEFT = /[,.;:!?)\]}…’”%]/;
+
+/**
+ * Characters that hug what follows them: text inserted straight after an open
+ * bracket or quote wants no space, and neither does the next character when the
+ * insert itself ends in one.
+ */
+const ATTACHES_RIGHT = /[([{“‘/]/;
+
+/**
+ * Space a handwritten insert into the sentence around it.
+ *
+ * What comes back from handwriting recognition is trimmed, because Scribble
+ * puts strays either end of almost everything it converts (issue #90). That is
+ * right for a line of its own and wrong in the middle of one: a writer adding
+ * "(CONTINUOUS)" to the end of a scene heading got `DAY(CONTINUOUS)`, and the
+ * panel now exists to make exactly those small in-line revisions, so it happens
+ * constantly rather than occasionally.
+ *
+ * `prevChar` and `nextChar` are the characters the insert lands between —
+ * empty at the start or end of a block, since nothing there needs joining.
+ * Punctuation is left alone in both directions: a space is added only where two
+ * pieces of ordinary text would otherwise run together.
+ */
+export function joinHandwriting(insert: string, prevChar: string, nextChar: string): string {
+  if (insert === '') return insert;
+
+  const needsBefore = prevChar !== ''
+    && !/\s/.test(prevChar)
+    && !ATTACHES_RIGHT.test(prevChar)
+    && !ATTACHES_LEFT.test(insert[0]);
+
+  const needsAfter = nextChar !== ''
+    && !/\s/.test(nextChar)
+    && !ATTACHES_LEFT.test(nextChar)
+    && !ATTACHES_RIGHT.test(insert[insert.length - 1]);
+
+  return `${needsBefore ? ' ' : ''}${insert}${needsAfter ? ' ' : ''}`;
+}

--- a/frontend/src/utils/pageCoords.test.ts
+++ b/frontend/src/utils/pageCoords.test.ts
@@ -1,0 +1,58 @@
+/**
+ * The overlay coordinate conversion. Getting the scale wrong is what puts a
+ * stand-in caret or a selection handle half a page from the text it belongs
+ * to once the writer zooms in.
+ */
+import { describe, it, expect } from 'vitest';
+import { pageScale, toPagePoint, type ScaledPage } from './pageCoords';
+
+/** A page laid out `offsetWidth` wide and painted `paintedWidth` wide. */
+const page = (offsetWidth: number, paintedWidth = offsetWidth, at = { left: 0, top: 0 }): ScaledPage => ({
+  offsetWidth,
+  getBoundingClientRect: () => ({ left: at.left, top: at.top, width: paintedWidth }),
+});
+
+describe('pageScale', () => {
+  it('is 1 when nothing is scaling the page', () => {
+    expect(pageScale(page(816))).toBe(1);
+  });
+
+  it('reads the zoom off the painted width', () => {
+    expect(pageScale(page(816, 1224))).toBe(1.5);
+    expect(pageScale(page(816, 408))).toBe(0.5);
+  });
+
+  it('has no answer for a page that is not laid out yet', () => {
+    expect(pageScale(page(0, 0))).toBeNull();
+    expect(pageScale(page(-1, 100))).toBeNull();
+  });
+
+  it('has no answer for a page painted at zero width', () => {
+    // Display:none inside the layout: a real offsetWidth, nothing painted.
+    expect(pageScale(page(816, 0))).toBeNull();
+  });
+});
+
+describe('toPagePoint', () => {
+  it('is relative to the page, not the viewport', () => {
+    const p = page(800, 800, { left: 100, top: 50 });
+    expect(toPagePoint(p, { left: 160, top: 90, bottom: 110 }))
+      .toEqual({ left: 60, top: 40, height: 20 });
+  });
+
+  it('undoes the zoom, so the point lands on its own text', () => {
+    const p = page(800, 1600, { left: 100, top: 50 });
+    // Twice the scale: a point 120px into the painted page is 60px into it.
+    expect(toPagePoint(p, { left: 220, top: 90, bottom: 130 }))
+      .toEqual({ left: 60, top: 20, height: 20 });
+  });
+
+  it('gives a collapsed rectangle a height worth drawing and grabbing', () => {
+    const p = page(800);
+    expect(toPagePoint(p, { left: 10, top: 40, bottom: 40 })?.height).toBe(8);
+  });
+
+  it('has no point for a page that is not laid out yet', () => {
+    expect(toPagePoint(page(0, 0), { left: 10, top: 40, bottom: 50 })).toBeNull();
+  });
+});

--- a/frontend/src/utils/pageCoords.test.ts
+++ b/frontend/src/utils/pageCoords.test.ts
@@ -56,3 +56,21 @@ describe('toPagePoint', () => {
     expect(toPagePoint(page(0, 0), { left: 10, top: 40, bottom: 50 })).toBeNull();
   });
 });
+
+describe('toPagePoint — cost of a reading', () => {
+  it('measures the page once, not once for the scale and again for the origin', () => {
+    // Called for both ends of a selection on every frame of a handle drag, and
+    // getBoundingClientRect forces layout: twice per end was twice the cost of
+    // the thing being kept smooth (issue #108).
+    let reads = 0;
+    const page = {
+      offsetWidth: 800,
+      getBoundingClientRect() {
+        reads++;
+        return { left: 10, top: 20, width: 1200 };
+      },
+    };
+    toPagePoint(page, { left: 100, top: 200, bottom: 220 });
+    expect(reads).toBe(1);
+  });
+});

--- a/frontend/src/utils/pageCoords.ts
+++ b/frontend/src/utils/pageCoords.ts
@@ -1,0 +1,67 @@
+/**
+ * Putting viewport coordinates into a page's own coordinate space.
+ *
+ * Anything the app draws over the script — the stand-in caret, the selection
+ * handles — is an absolutely positioned child of `.page`, so it has to be
+ * placed in that element's *unscaled* coordinates. ProseMirror answers in
+ * viewport coordinates, which are scaled: the editor is zoomed by a transform
+ * on an ancestor, and at 150% a caret placed straight from `coordsAtPos` sits
+ * half a page away from the text it belongs to.
+ *
+ * The conversion is a measurement rather than a calculation, so nothing here
+ * has to know how the page is being scaled, by which ancestor, or whether the
+ * writer has changed it since.
+ */
+
+/** The parts of the page element this needs; an interface so tests can stub it. */
+export interface ScaledPage {
+  offsetWidth: number;
+  getBoundingClientRect(): { left: number; top: number; width: number };
+}
+
+/** A viewport rectangle, as ProseMirror's `coordsAtPos` returns one. */
+export interface ViewportRect {
+  left: number;
+  top: number;
+  bottom: number;
+}
+
+/** A point in the page's unscaled coordinate space. */
+export interface PagePoint {
+  left: number;
+  top: number;
+  height: number;
+}
+
+/**
+ * The scale an ancestor is painting `page` at: painted width over layout
+ * width. 1 when nothing is scaling it.
+ *
+ * Null when the answer cannot be trusted — a page not laid out yet has no
+ * width to divide by, and dividing anyway yields Infinity or NaN.
+ */
+export function pageScale(page: ScaledPage): number | null {
+  if (page.offsetWidth <= 0) return null;
+  const scale = page.getBoundingClientRect().width / page.offsetWidth;
+  if (!Number.isFinite(scale) || scale <= 0) return null;
+  return scale;
+}
+
+/**
+ * `rect`, in viewport coordinates, expressed relative to `page` and undone of
+ * whatever scale the page is drawn at.
+ *
+ * The height has a floor: a collapsed rectangle — which is what an empty line
+ * can measure — would otherwise give a caret or a handle no height at all, and
+ * nothing to see or to grab.
+ */
+export function toPagePoint(page: ScaledPage, rect: ViewportRect): PagePoint | null {
+  const scale = pageScale(page);
+  if (scale === null) return null;
+  const bounds = page.getBoundingClientRect();
+  return {
+    left: (rect.left - bounds.left) / scale,
+    top: (rect.top - bounds.top) / scale,
+    height: Math.max(8, (rect.bottom - rect.top) / scale),
+  };
+}

--- a/frontend/src/utils/pageCoords.ts
+++ b/frontend/src/utils/pageCoords.ts
@@ -26,6 +26,22 @@ export interface ViewportRect {
   bottom: number;
 }
 
+/** A viewport rectangle with all four edges, as `getClientRects` returns them. */
+export interface ViewportBox {
+  left: number;
+  top: number;
+  right: number;
+  bottom: number;
+}
+
+/** A rectangle in the page's unscaled coordinate space. */
+export interface PageRect {
+  left: number;
+  top: number;
+  width: number;
+  height: number;
+}
+
 /** A point in the page's unscaled coordinate space. */
 export interface PagePoint {
   left: number;
@@ -41,8 +57,18 @@ export interface PagePoint {
  * width to divide by, and dividing anyway yields Infinity or NaN.
  */
 export function pageScale(page: ScaledPage): number | null {
-  if (page.offsetWidth <= 0) return null;
-  const scale = page.getBoundingClientRect().width / page.offsetWidth;
+  return scaleOf(page.offsetWidth, page.getBoundingClientRect().width);
+}
+
+/**
+ * The same division, over a width already measured — so a caller that needs
+ * the rectangle as well as the scale can read the element once instead of
+ * twice. `toPagePoint` is called for each end of a selection on every frame of
+ * a handle drag, and each of those was two forced layouts rather than one.
+ */
+function scaleOf(offsetWidth: number, paintedWidth: number): number | null {
+  if (offsetWidth <= 0) return null;
+  const scale = paintedWidth / offsetWidth;
   if (!Number.isFinite(scale) || scale <= 0) return null;
   return scale;
 }
@@ -56,12 +82,32 @@ export function pageScale(page: ScaledPage): number | null {
  * nothing to see or to grab.
  */
 export function toPagePoint(page: ScaledPage, rect: ViewportRect): PagePoint | null {
-  const scale = pageScale(page);
-  if (scale === null) return null;
   const bounds = page.getBoundingClientRect();
+  const scale = scaleOf(page.offsetWidth, bounds.width);
+  if (scale === null) return null;
   return {
     left: (rect.left - bounds.left) / scale,
     top: (rect.top - bounds.top) / scale,
     height: Math.max(8, (rect.bottom - rect.top) / scale),
+  };
+}
+
+/**
+ * `box`, in viewport coordinates, as a rectangle in the page's own space.
+ *
+ * The same conversion `toPagePoint` does, for the bands that stand in for a
+ * selection highlight the system has stopped painting. No height floor: unlike
+ * a caret, a band of no height is a line with nothing on it, and drawing it
+ * 8px tall would put a stripe under an empty line.
+ */
+export function toPageRect(page: ScaledPage, box: ViewportBox): PageRect | null {
+  const bounds = page.getBoundingClientRect();
+  const scale = scaleOf(page.offsetWidth, bounds.width);
+  if (scale === null) return null;
+  return {
+    left: (box.left - bounds.left) / scale,
+    top: (box.top - bounds.top) / scale,
+    width: (box.right - box.left) / scale,
+    height: (box.bottom - box.top) / scale,
   };
 }

--- a/frontend/src/utils/pasteFountain.test.ts
+++ b/frontend/src/utils/pasteFountain.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Paste as Fountain used to insert *everything* as blocks, including a scrap
+ * of ordinary prose that Fountain only calls Action because Action is its
+ * default. With the caret inside `EXT. CARGO| SHIP - PIER 3 - INTERCUT` that
+ * split the heading in three (issue #109). These cover the line between text
+ * the writer typed and structure the writer marked up.
+ */
+import { describe, it, expect } from 'vitest';
+import { planFountainInsert } from './pasteFountain';
+
+describe('planFountainInsert — plain text goes in at the caret', () => {
+  it('offers a single unmarked line as inline text', () => {
+    const plan = planFountainInsert('Across the yard');
+    expect(plan?.inline).toEqual([{ type: 'text', text: 'Across the yard' }]);
+  });
+
+  it('still parses that line as Action for anywhere inline cannot land', () => {
+    expect(planFountainInsert('Across the yard')?.blocks).toEqual([
+      { type: 'action', content: [{ type: 'text', text: 'Across the yard' }] },
+    ]);
+  });
+
+  it('keeps emphasis on inline text', () => {
+    const plan = planFountainInsert('a *whispered* word');
+    expect(plan?.inline).toHaveLength(3);
+    expect(plan?.inline?.[1]).toMatchObject({
+      text: 'whispered',
+      marks: [{ type: 'italic' }],
+    });
+  });
+
+  it('ignores blank lines around the text', () => {
+    expect(planFountainInsert('\n\nAcross the yard\n\n')?.inline).toEqual([
+      { type: 'text', text: 'Across the yard' },
+    ]);
+  });
+
+  it('has nothing to insert for empty or blank text', () => {
+    expect(planFountainInsert('')).toBeNull();
+    expect(planFountainInsert('   \n  ')).toBeNull();
+  });
+});
+
+describe('planFountainInsert — structure keeps its own blocks', () => {
+  const staysBlocks = (label: string, text: string) =>
+    it(label, () => {
+      const plan = planFountainInsert(text);
+      expect(plan?.inline).toBeUndefined();
+      expect(plan?.blocks.length).toBeGreaterThan(0);
+    });
+
+  staysBlocks('a scene heading', 'INT. KITCHEN - DAY');
+  staysBlocks('a forced scene heading', '.PIER 3');
+  staysBlocks('a transition', 'CUT TO:');
+  staysBlocks('a forced transition', '> SMASH CUT:');
+  staysBlocks('a section', '# Act One');
+  staysBlocks('lyrics', '~ and the band played on');
+  staysBlocks('a character cue with dialogue', 'SAM\nWe should go.');
+  staysBlocks('two lines of action', 'Across the yard.\n\nA gull lands.');
+  staysBlocks('a title page', 'Title: Cargo\nAuthor: Alex Example');
+
+  it('honours a forced Action line as a block of its own', () => {
+    // `!` is the writer saying "make this Action", so it gets an Action block
+    // even though what is left after the marker is one plain line.
+    const plan = planFountainInsert('!Across the yard');
+    expect(plan?.inline).toBeUndefined();
+    expect(plan?.blocks).toEqual([
+      { type: 'action', content: [{ type: 'text', text: 'Across the yard' }] },
+    ]);
+  });
+
+  it('keeps centred text as a block, since the centring is structure', () => {
+    const plan = planFountainInsert('>THE END<');
+    expect(plan?.inline).toBeUndefined();
+    expect(plan?.blocks[0]).toMatchObject({ attrs: { textAlign: 'center' } });
+  });
+
+  it('keeps a page break with the line it applies to', () => {
+    const plan = planFountainInsert('===\nAcross the yard');
+    expect(plan?.inline).toBeUndefined();
+    expect(plan?.blocks[0]).toMatchObject({ attrs: { startsNewPage: true } });
+  });
+});

--- a/frontend/src/utils/pasteFountain.test.ts
+++ b/frontend/src/utils/pasteFountain.test.ts
@@ -35,6 +35,25 @@ describe('planFountainInsert — plain text goes in at the caret', () => {
     ]);
   });
 
+  // A leading `.` forces a scene heading in Fountain, but only where the next
+  // character is not a second `.` — which is exactly what stops an ellipsis
+  // being read as markup. Dialogue continuation is written that way constantly,
+  // so this is the plain line most likely to be pasted into the middle of an
+  // element (issue #109).
+  it('treats a line opening with an ellipsis as text, not a forced heading', () => {
+    expect(planFountainInsert('...and then I left')?.inline).toEqual([
+      { type: 'text', text: '...and then I left' },
+    ]);
+  });
+
+  it('treats a bare pair of dots as text', () => {
+    expect(planFountainInsert('..')?.inline).toEqual([{ type: 'text', text: '..' }]);
+  });
+
+  it('treats a lone full stop as text', () => {
+    expect(planFountainInsert('.')?.inline).toEqual([{ type: 'text', text: '.' }]);
+  });
+
   it('has nothing to insert for empty or blank text', () => {
     expect(planFountainInsert('')).toBeNull();
     expect(planFountainInsert('   \n  ')).toBeNull();
@@ -51,6 +70,9 @@ describe('planFountainInsert — structure keeps its own blocks', () => {
 
   staysBlocks('a scene heading', 'INT. KITCHEN - DAY');
   staysBlocks('a forced scene heading', '.PIER 3');
+  // The qualified `.` rule must not go so far the other way that a real forced
+  // heading whose text begins with a dot-word slips through as prose.
+  staysBlocks('a forced scene heading of one word', '.LATER');
   staysBlocks('a transition', 'CUT TO:');
   staysBlocks('a forced transition', '> SMASH CUT:');
   staysBlocks('a section', '# Act One');

--- a/frontend/src/utils/pasteFountain.ts
+++ b/frontend/src/utils/pasteFountain.ts
@@ -14,19 +14,99 @@ import { parseFountain } from './fountainParser';
 import { pasteFailureMessage, readNativeText } from './clipboardCommands';
 
 /**
+ * How a Fountain paste should land at the caret.
+ *
+ * `blocks` is the whole point of the command: the clipboard described
+ * screenplay elements, so screenplay elements are what get inserted.
+ *
+ * `inline` is the case Fountain cannot distinguish on its own. Every line the
+ * format does not recognise is Action by default, so a scrap of ordinary prose
+ * — "Across the yard" — parses as an Action block, and inserting a block in
+ * the middle of an element splits it: a caret in `EXT. CARGO| SHIP - PIER 3`
+ * came back as three blocks, the heading torn in half around the paste
+ * (issue #109). That text carries no structure to honour, so it goes in as
+ * text, at the caret, in whatever element the writer put the caret in.
+ */
+export interface FountainInsert {
+  /** The screenplay elements the text parsed to. */
+  blocks: JSONContent[];
+  /**
+   * Set only for the plain-text case: the inline content to drop at the caret
+   * instead, leaving the destination element and its type intact.
+   */
+  inline?: JSONContent[];
+}
+
+/**
+ * Fountain's forcing characters. A line that opens with one is markup even
+ * when it is a single line: `!Across the yard` is the writer saying "this is
+ * Action", so it gets an Action block rather than being poured into the
+ * heading the caret happens to be in.
+ *
+ * Only `!` can reach the inline test — the rest already parse to something
+ * other than a bare Action node — but the whole set is listed because the test
+ * is about what the writer wrote, not about which rule happened to claim it.
+ */
+const FORCED_ELEMENT = /^[!@>~.#=]/;
+
+/**
+ * Decide what `text` should become when pasted as Fountain.
+ *
+ * Returns null when there is nothing to insert.
+ */
+export function planFountainInsert(text: string): FountainInsert | null {
+  if (!text || text.trim() === '') return null;
+
+  const parsed = parseFountain(text) as JSONContent;
+  // Insert the blocks themselves, not the doc wrapper — setContent would
+  // replace the whole script rather than paste into it.
+  const content = parsed.content ?? [];
+  if (content.length === 0) return null;
+
+  const inline = asInlineText(content, text);
+  return inline ? { blocks: content, inline } : { blocks: content };
+}
+
+/**
+ * The inline content of a paste that turned out to be plain text, or null if
+ * it turned out to be anything else.
+ *
+ * Plain text is one Action node, from one line, with nothing on it: an
+ * attribute means the parser found markup that survived into the node — a
+ * `===` page break ahead of it, the `>centred<` alignment — and that is
+ * structure, so it keeps its block. Emphasis marks are not structure and come
+ * through, so pasting `*whispered*` mid-sentence still arrives italic.
+ */
+function asInlineText(content: JSONContent[], text: string): JSONContent[] | null {
+  if (content.length !== 1) return null;
+  const [node] = content;
+  if (node.type !== 'action') return null;
+  if (node.attrs && Object.keys(node.attrs).length > 0) return null;
+  if (!node.content || node.content.length === 0) return null;
+
+  const trimmed = text.trim();
+  if (trimmed.includes('\n')) return null;
+  if (FORCED_ELEMENT.test(trimmed)) return null;
+
+  return node.content;
+}
+
+/**
  * Parse `text` as Fountain and insert it at the current selection.
  * Returns false when there was nothing to insert.
  */
 export function insertFountainText(editor: Editor, text: string): boolean {
-  if (!text || text.trim() === '') return false;
+  const plan = planFountainInsert(text);
+  if (!plan) return false;
 
-  const parsed = parseFountain(text) as JSONContent;
-  const content = parsed.content ?? [];
-  if (content.length === 0) return false;
+  // Inline content needs a textblock to go into. Anything else — a node
+  // selection on an image, a gap cursor between blocks — has no caret inside
+  // an element to insert at, so the blocks are the only form that can land.
+  const inline = plan.inline && editor.state.selection.$from.parent.isTextblock
+    ? plan.inline
+    : null;
 
-  // Insert the blocks themselves, not the doc wrapper — setContent would
-  // replace the whole script rather than paste into it.
-  editor.chain().focus().insertContent(content).run();
+  editor.chain().focus().insertContent(inline ?? plan.blocks).run();
   return true;
 }
 

--- a/frontend/src/utils/pasteFountain.ts
+++ b/frontend/src/utils/pasteFountain.ts
@@ -43,11 +43,22 @@ export interface FountainInsert {
  * Action", so it gets an Action block rather than being poured into the
  * heading the caret happens to be in.
  *
- * Only `!` can reach the inline test — the rest already parse to something
- * other than a bare Action node — but the whole set is listed because the test
- * is about what the writer wrote, not about which rule happened to claim it.
+ * `.` is the one that has to be qualified, because it is the one character
+ * here that also starts ordinary prose. Fountain forces a scene heading on a
+ * leading `.` only where the next character is not a second `.`, which is what
+ * keeps an ellipsis from becoming a heading — so `...and then I left`, the
+ * shape half of dialogue continuation takes, is prose that the parser already
+ * hands back as a plain Action. Matching it here anyway sent it in as a block
+ * and split the element the caret was in: issue #109 again, on the paste most
+ * likely to land mid-sentence. The lookahead mirrors the parser's own rule.
+ *
+ * The rest need no qualifying: `@`, `>`, `~` and `#` parse to something other
+ * than a bare Action node and are turned away before this test is reached, and
+ * `!` forces Action unconditionally, marker consumed. They are listed all the
+ * same, because the question is what the writer marked up, not which rule
+ * happened to claim it.
  */
-const FORCED_ELEMENT = /^[!@>~.#=]/;
+const FORCED_ELEMENT = /^(?:[!@>~#=]|\.(?=[^.]))/;
 
 /**
  * Decide what `text` should become when pasted as Fountain.

--- a/user-manual/import-export.html
+++ b/user-manual/import-export.html
@@ -143,6 +143,8 @@
     <h3 id="paste-fountain">Paste as Fountain</h3>
     <p>To bring in part of a script rather than a whole file, copy the Fountain text and use <strong>Edit &gt; Paste as Fountain</strong> (or <kbd>Shift</kbd>+<kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>V</kbd>, also on the right-click menu). The pasted text is run through the Fountain parser and inserted at the cursor as real screenplay elements, instead of landing as one block of whatever element you were already in.</p>
 
+    <p>A single line of ordinary text is the exception. Fountain calls anything it does not recognise Action, so pasting <em>Across the yard</em> in the middle of a scene heading would otherwise break the heading in two and drop an Action line between the halves. Text like that is inserted at the cursor instead, keeping the element you are in &mdash; exactly as an ordinary paste would. Anything Fountain does recognise, including a line you have marked as Action yourself with a leading <code>!</code>, still arrives as its own element.</p>
+
     <div class="callout callout-info">
       <span class="callout-icon">&#8505;&#65039;</span>
       <div class="callout-content">

--- a/user-manual/manifest.json
+++ b/user-manual/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "228b95fd05be28ba",
+  "version": "8c5444191049b416",
   "pages": [
     {
       "slug": "index.html",
@@ -23,7 +23,7 @@
       "slug": "writing-screenplay.html",
       "title": "Writing Your Screenplay",
       "section": "Writing",
-      "hash": "4d982076f345e027"
+      "hash": "fff840cc592bde49"
     },
     {
       "slug": "formatting.html",

--- a/user-manual/manifest.json
+++ b/user-manual/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "fff45ed323b5e242",
+  "version": "228b95fd05be28ba",
   "pages": [
     {
       "slug": "index.html",
@@ -23,7 +23,7 @@
       "slug": "writing-screenplay.html",
       "title": "Writing Your Screenplay",
       "section": "Writing",
-      "hash": "3a730948d6dda450"
+      "hash": "4d982076f345e027"
     },
     {
       "slug": "formatting.html",
@@ -125,7 +125,7 @@
       "slug": "import-export.html",
       "title": "Import & Export",
       "section": "Projects & Files",
-      "hash": "743a38515442e12b"
+      "hash": "7fe6cc38be6690c5"
     },
     {
       "slug": "format-compatibility.html",

--- a/user-manual/search.js
+++ b/user-manual/search.js
@@ -192,7 +192,7 @@
     { page: 'Import & Export', title: 'Export as Final Draft', section: 'Export FDX', text: 'Save as Final Draft FDX file. Preserves character profiles tag categories entities.', url: 'import-export.html#export-fdx' },
     { page: 'Import & Export', title: 'Export as Fountain', section: 'Export Fountain', text: 'Save as Fountain plain-text format. Compatible any Fountain editor version control.', url: 'import-export.html#export-fountain' },
 
-    { page: 'Writing Your Screenplay', title: 'Handwriting with an Apple Pencil', section: 'Handwriting', text: 'Apple Pencil Scribble iPad handwriting input box. Write with pencil insert at cursor. Replaces selection. Scribble overwrites deletes existing text middle of screenplay cramped small writing area. Safe large writing box.', url: 'writing-screenplay.html#handwriting' },
+    { page: 'Writing Your Screenplay', title: 'Handwriting with an Apple Pencil', section: 'Handwriting', text: 'Apple Pencil Scribble iPad handwriting input box. Edit menu Handwriting three-finger context menu. Write with pencil insert at cursor. Replaces selection. Floating panel stays open drag by title bar move insertion point tap script preview clear close. Scribble overwrites deletes existing text middle of screenplay cramped small writing area. Safe large writing box.', url: 'writing-screenplay.html#handwriting' },
 
     // Format Compatibility
     { page: 'Format Compatibility', title: 'Format Compatibility', section: '', text: 'What each screenplay element becomes when exported. Lossy conversion round trip. Which elements are lost changed converted flattened. Element mapping table fdx fountain docx osf fadein odraft.', url: 'format-compatibility.html' },

--- a/user-manual/writing-screenplay.html
+++ b/user-manual/writing-screenplay.html
@@ -318,6 +318,8 @@
       <li>Triple-click a line to select the entire paragraph</li>
     </ul>
 
+    <p>On iPhone and iPad, a selection carries a handle at each end. Drag either one to widen or narrow the selection a word or a letter at a time, without having to start the selection again.</p>
+
     <h2 id="right-click-menu">Right-Click Context Menu</h2>
 
     <p>Right-clicking in the editor opens a context menu with quick access to:</p>

--- a/user-manual/writing-screenplay.html
+++ b/user-manual/writing-screenplay.html
@@ -275,16 +275,34 @@
     <h2 id="handwriting">Handwriting with an Apple Pencil (iPad)</h2>
 
     <p>
-      Tap the <strong>handwriting</strong> button on the bar above the keyboard to open a large,
-      empty writing box. Write in it with your Apple Pencil at whatever size is comfortable; when you
-      tap <strong>Insert</strong>, what you wrote is placed in the script at your cursor. If you had
-      text selected before opening it, the handwriting replaces that selection.
+      Choose <strong>Edit &rarr; Handwriting&hellip;</strong> &mdash; or <strong>Handwriting&hellip;</strong>
+      on the three-finger context menu &mdash; to open a large, empty writing box. Write in it with your
+      Apple Pencil at whatever size is comfortable; when you tap <strong>Insert</strong>, what you wrote is
+      placed in the script at your cursor. If you had text selected, the handwriting replaces that selection.
     </p>
+
+    <p>
+      The box is a <strong>floating panel, not a dialog</strong>. It stays open while you work, and the
+      script behind it stays live, so a whole pass over a scene takes one panel rather than one per edit:
+    </p>
+
+    <ul>
+      <li><strong>Tap anywhere in the script to move where the text will go.</strong> The panel follows
+        your cursor &mdash; the preview at the top of it updates, and the caret on the page shows the spot.</li>
+      <li><strong>Insert leaves the panel open and empty</strong>, with the cursor after what it just
+        inserted, ready for the next line.</li>
+      <li><strong>Drag the panel by its title bar</strong> to move it off the part of the page you are
+        working on. Where you leave it is remembered.</li>
+      <li><strong>Preview</strong> hides or shows the picture of the script around your cursor, if you
+        would rather have the space to write in.</li>
+      <li><strong>Clear</strong> empties the writing box without closing the panel &mdash; useful when a
+        word came out wrong. <strong>&times;</strong>, or <kbd>Esc</kbd>, closes the panel; nothing else
+        does, so a stray palm or Pencil tip cannot throw away what you have written.</li>
+    </ul>
 
     <ul>
       <li>Write several lines and each becomes its own paragraph, in the element your cursor was in.</li>
       <li>Write a single line and it is inserted into the sentence you were already in.</li>
-      <li><strong>Cancel</strong> discards what you wrote and leaves the script untouched.</li>
     </ul>
 
     <div class="callout callout-info">

--- a/user-manual/writing-screenplay.html
+++ b/user-manual/writing-screenplay.html
@@ -302,7 +302,10 @@
 
     <ul>
       <li>Write several lines and each becomes its own paragraph, in the element your cursor was in.</li>
-      <li>Write a single line and it is inserted into the sentence you were already in.</li>
+      <li>Write a single line and it is inserted into the sentence you were already in, spaced into
+        it &mdash; write <em>(CONTINUOUS)</em> at the end of a scene heading and you get
+        <em>INT. KITCHEN - DAY (CONTINUOUS)</em>, not <em>DAY(CONTINUOUS)</em>. Punctuation stays put:
+        a word written in front of a full stop does not push it away.</li>
     </ul>
 
     <div class="callout callout-info">


### PR DESCRIPTION
## What does this PR do?

Four commits on one branch. The handwriting work (#90) is the bulk of it; the other two were already on the branch when it was opened, and this PR was originally raised for the last of them.

### Handwriting is a floating panel now (#90) — `bd96f9a`, `1495f69`

Follows the reporter's feedback after testing v2.0.0 on an iPad. The modal sheet had to be closed before the page underneath could be touched, so moving the insertion point cost Cancel → tap the new line → Edit → Handwriting… again. Four taps per edit, on the device where a writer is least likely to have a keyboard to fall back on.

- No backdrop: the script behind stays live, and tapping a line there is how you choose where the next insert lands. The insertion point is the editor's own selection, read as it changes, rather than a position captured when the panel opened.
- Insert leaves the panel open and the field empty, with the selection after what it inserted, so a run of small revisions is one panel and no reopening.
- The insert chain no longer calls `.focus()` — focusing the editor would take the Pencil out of the writing field on every insert. Focus returns to the field.
- `PencilCaret` keeps drawing while the panel holds focus: iPadOS paints no caret in an unfocused web view, so the target line would otherwise have nothing marking it. There is still only ever one caret, since an unfocused view has none of its own.
- Dragged by its header (pointer capture, `touch-action: none` so the drag does not scroll the script under it); position remembered and always clamped into the visual viewport, so a rotation, a resize or the keyboard coming up cannot strand the header off the edge.
- After an insert the caret is lifted out from under the panel, and only ever upward: ProseMirror's `scrollIntoView` counts anything inside the window as visible, and the panel floats over the window.
- Smaller than the sheet was (150px preview, 190px writing area against 210 and 300), and the preview folds away. Cancel becomes Clear; closing is the × or `Esc`, and nothing else dismisses it.
- Spacing: recognition output is trimmed, which is right for a line of its own and wrong in the middle of one — `(CONTINUOUS)` at the end of a scene heading produced `DAY(CONTINUOUS)`. A single-line insert is now spaced against the characters it lands between, leaving punctuation alone in both directions. Several lines still become blocks of their own.

Placement arithmetic, the paragraph rule and the spacing rule live in `utils/handwriting.ts`, where they are testable without a document or an iPad.

### A selection on iPad gets handles to drag (#108) — `63b431c`

### Paste a plain line as text, not as a block that splits the element (#109) — `f16fbe3`

Fountain calls every line it does not recognise Action, so "Across the yard" — ordinary prose, no markup — parsed to an Action block like any other. Paste as Fountain inserted it as a block, and a block inserted mid-element splits it: a caret in `EXT. CARGO| SHIP - PIER 3 - INTERCUT` came back as three blocks with the heading torn in half around the paste.

The parse now says which of the two it found. One unmarked line with nothing on it is text and goes in at the caret, keeping the element the writer put the caret in, the way an ordinary paste does. Anything with structure to honour — a heading, a cue and its dialogue, a transition, a centred line, a page break, or a line the writer marked as Action with a leading `!` — still arrives as the elements the markup describes. Emphasis is not structure and comes through either way, so pasting `*whispered*` mid-sentence still lands italic.

Related: #90, #108, #109. No issue state is changed by this PR — #90's reporter is testing the panel first.

## Type of change

- [x] Bug fix
- [x] New feature
- [ ] Refactoring (no functional change)
- [x] Documentation
- [ ] Other (describe below)

## How was this tested?

Handwriting (#90):

- `npx vitest run` — 69 files, 1041 tests passing, including 19 new ones for the panel placement, paragraph and spacing rules.
- `npm run build` (tsc + vite) clean; `eslint` clean on every changed file.
- Driven in a real browser (Playwright/Chromium, 1180×820) against the running editor, with no console or page errors:
  - the panel stays open after Insert and the field clears;
  - tapping another line retargets it — the preview and element badge follow — and the next insert lands there;
  - dragging moves it, the position is stored, and a drag far off-screen clamps back inside the viewport;
  - the preview toggle and `Esc` behave.
- Spacing checked case by case in the same editor: `INT. KITCHEN - DAY (CONTINUOUS)` at end of line; `Mara slowly pours the coffee.` mid-line; `...the coffee again.` written in front of the full stop; no leading space at the start of a line; a two-line insert still becoming two paragraphs.

Not yet tested on a physical iPad with a Pencil — that is what the reporter is doing. The #108 and #109 commits carry their own unit tests, which are part of the run above.

## Screenshots (if applicable)

Not attached. The handwriting panel is a floating card at the foot of the window: header with a drag grip, the current element badge, Keyboard/Preview toggles and a close button; the script preview with the target line highlighted; the writing field; the Enter/Backspace/Select All/Cut/Copy/Paste row; Clear and Insert.

## Checklist

- [x] I've read the [Contributing Guide](docs/CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I've tested my changes locally
- [x] I've updated documentation if needed — the manual described a keyboard-accessory-bar button that has not existed since handwriting shipped; it now describes the menus that open the panel, how it stays open, and the spacing rule (`manifest.json` regenerated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UpWx7u6j4GtyaTaHZpnLyQ