### PR TITLE
Ask each Apple storefront its own version, not one for both

### DIFF
--- a/.github/workflows/store-watch.yml
+++ b/.github/workflows/store-watch.yml
@@ -72,6 +72,22 @@ jobs:
           echo "version=${TAG#v}" >> "$GITHUB_OUTPUT"
           echo "Target: ${TAG#v}"
 
+      # The store versions this workflow published last time. main's store
+      # entries are stale by design — they are only moved by hand, and were
+      # still on 1.8 while the stores served 2.x — so recomposing from main
+      # alone means one lookup that cannot answer republishes 1.8 and takes
+      # the notice away from that store until some later run succeeds.
+      - name: The manifest as last published
+        id: previous
+        run: |
+          if git fetch --depth=1 origin manifest \
+             && git show FETCH_HEAD:landing/updates.json > /tmp/previous-updates.json; then
+            echo "path=/tmp/previous-updates.json" >> "$GITHUB_OUTPUT"
+          else
+            echo "No published manifest to carry forward — first run since the branch was removed."
+            echo "path=" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Ask the stores what is live
         id: check
         env:
@@ -83,7 +99,9 @@ jobs:
           else
             echo "::warning::GOOGLE_PLAY_SERVICE_ACCOUNT_JSON_BASE64 not set — the play channel cannot be checked"
           fi
-          python3 test-script/refresh_store_manifest.py --target "${{ steps.target.outputs.version }}" | tee /tmp/out.txt
+          python3 test-script/refresh_store_manifest.py \
+            --target "${{ steps.target.outputs.version }}" \
+            --previous "${{ steps.previous.outputs.path }}" | tee /tmp/out.txt
           grep -E '^(changed|caught-up)=' /tmp/out.txt >> "$GITHUB_OUTPUT"
 
       # Published to a branch, not to main. main requires a pull request, and

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -70,8 +70,22 @@ send people to a listing still offering the build they already have. They are
 moved later by the **Store Watch** workflow, which asks each store what it is
 actually serving:
 
-- Apple — the iTunes lookup API, no credentials. One record covers both the iOS
-  and Mac App Store entries for this app id, so those two channels move together.
+- Apple — the iTunes lookup API, no credentials. Asked **twice**, once per
+  storefront: the iOS and Mac App Store entries share an app id and a product
+  page, but they are separate records (`software` and `mac-software`, the latter
+  needing `entity=macSoftware`) at separate versions, because review approves
+  the two builds separately. v2.1.0 was the proof — the single default record is
+  the iOS one, and writing it to both channels pinned `mas` to 2.0.0 while the
+  Mac App Store was already serving 2.1.0, so Mac App Store users on 2.0.0 were
+  told they were up to date. Whichever record is missing from a reply is
+  reported as unknown; the other platform's version is never a substitute.
+- A store channel never moves backwards. Every run recomposes the manifest from
+  `main`, whose store entries are stale by design, so the versions the last run
+  published (read off the `manifest` branch and passed in as `--previous`) are
+  floors. Without that, one lookup that could not answer would republish
+  `main`'s old version and take the notice away from that store until a later
+  run happened to succeed. To correct a store channel downwards, delete the
+  `manifest` branch.
 - Google — the Play Developer API, using the same
   `GOOGLE_PLAY_SERVICE_ACCOUNT_JSON_BASE64` secret `submit-stores.yml` uses. The
   track release's name is preferred; the versionCode is the fallback, decoded

--- a/test-script/refresh_store_manifest.py
+++ b/test-script/refresh_store_manifest.py
@@ -11,8 +11,10 @@ That distinction matters: the failure mode of guessing is a notice telling
 someone to update from a store page that still offers the version they have.
 
   Apple  itunes lookup, no credentials. Reports the reviewed, published
-         version — exactly the question being asked. One record covers both
-         the iOS and Mac App Store entries for this app id.
+         version — exactly the question being asked. Asked twice, once per
+         storefront: the iOS and Mac App Store entries share an app id and a
+         product page but are separate records at separate versions, since
+         review approves the two builds separately.
   Google no public equivalent, so the Play Developer API, which is fine here:
          this runs in CI with the service account submit-stores.yml already
          uses. A track release carries a name (the versionName) and the
@@ -61,19 +63,40 @@ def get_json(url, headers=None, data=None, method=None):
 
 # ── Apple ────────────────────────────────────────────────────────────────────
 
-def apple_live_version():
-    """The version the App Store is serving, or None if it cannot be read."""
+def apple_live_version(kind):
+    """The version one Apple storefront is serving, or None if unreadable.
+
+    `kind` is the record type the lookup returns: `software` for the iOS App
+    Store, `mac-software` for the Mac App Store. Each is asked for separately
+    and neither answers for the other, because the two move independently —
+    review approves the iOS and Mac builds on their own schedules, so on any
+    given day one platform can be a release ahead of the other.
+
+    The kind is checked rather than trusted. A lookup that cannot serve the
+    entity asked for answers with the record it has instead, and taking that
+    would publish one platform's version as the other's.
+    """
+    entity = 'macSoftware' if kind == 'mac-software' else 'software'
     url = ('https://itunes.apple.com/lookup?'
-           + urllib.parse.urlencode({'id': APPLE_APP_ID, 'country': 'us'}))
+           + urllib.parse.urlencode({'id': APPLE_APP_ID, 'country': 'us',
+                                     'entity': entity}))
     try:
         data = get_json(url)
     except (urllib.error.URLError, json.JSONDecodeError, TimeoutError) as err:
-        print(f'  ! apple: lookup failed ({err})', file=sys.stderr)
+        print(f'  ! apple: {kind} lookup failed ({err})', file=sys.stderr)
         return None
-    if not data.get('resultCount'):
-        print('  ! apple: app id returned no results', file=sys.stderr)
-        return None
-    return data['results'][0].get('version')
+    return apple_version_of(data.get('results') or [], kind)
+
+
+def apple_version_of(results, kind):
+    """The version of the one lookup result of this kind, or None."""
+    for result in results:
+        if result.get('kind') == kind:
+            return result.get('version')
+    got = ', '.join(sorted({str(r.get('kind')) for r in results})) or 'nothing'
+    print(f'  ! apple: no {kind} record for app id {APPLE_APP_ID} '
+          f'(lookup returned {got})', file=sys.stderr)
+    return None
 
 
 # ── Google Play ──────────────────────────────────────────────────────────────
@@ -152,10 +175,54 @@ def play_live_version(sa_json):
 
 # ── main ─────────────────────────────────────────────────────────────────────
 
+STORE_CHANNELS = ('ios', 'mas', 'play')
+
+
+def raise_store_channels(channels, previous):
+    """Stop a store channel from going backwards. Returns True if any moved.
+
+    Every run recomposes the manifest from main, whose store entries are
+    whatever was last committed by hand — 1.8 while the stores were serving
+    2.x. So one lookup that cannot answer would republish that stale version
+    and take the notice away from a whole store until some later run happened
+    to succeed, which is the failure this whole script exists to avoid.
+
+    A store never un-releases a build, so the version last published is a
+    floor. The cost is that a store channel cannot be corrected downwards by
+    editing main; delete the manifest branch to do that.
+    """
+    moved = False
+    for name in STORE_CHANNELS:
+        entry = previous.get(name)
+        was = entry.get('version') if isinstance(entry, dict) else None
+        if name not in channels or not was:
+            continue
+        if version_tuple(was) > version_tuple(channels[name]['version']):
+            print(f'  ↑ {name:5} {channels[name]["version"]} → {was} '
+                  f'(as last published)')
+            channels[name]['version'] = was
+            moved = True
+    return moved
+
+
+def previous_channels(path):
+    """The store versions as last published, or {} if there is no reading it."""
+    if not path:
+        return {}
+    try:
+        with open(path, encoding='utf-8') as fh:
+            return json.load(fh).get('channels') or {}
+    except (OSError, json.JSONDecodeError, AttributeError) as err:
+        print(f'  ! previous manifest unreadable ({err})', file=sys.stderr)
+        return {}
+
+
 def main():
     ap = argparse.ArgumentParser()
     ap.add_argument('--target', help='version the stores are catching up to '
                                      '(default: the dmg channel)')
+    ap.add_argument('--previous', help='the manifest as last published; its '
+                                       'store versions are floors')
     args = ap.parse_args()
 
     with open(MANIFEST, encoding='utf-8') as fh:
@@ -165,20 +232,28 @@ def main():
     target = args.target or channels['dmg']['version']
     print(f'target: {target}')
 
-    apple = apple_live_version()
-    print(f'  apple live: {apple or "unknown"}')
+    ios = apple_live_version('software')
+    mac = apple_live_version('mac-software')
+    print(f'  apple ios live: {ios or "unknown"}')
+    print(f'  apple mac live: {mac or "unknown"}')
     play = play_live_version(os.environ.get('PLAY_SERVICE_ACCOUNT_JSON', ''))
-    print(f'  play  live: {play or "unknown"}')
+    print(f'  play      live: {play or "unknown"}')
 
-    # One Apple record covers both storefront entries for this app id, so the
-    # iOS and Mac App Store channels move together.
-    found = {'ios': apple, 'mas': apple, 'play': play}
+    # One product page, one app id, two records — and they are not
+    # interchangeable. The v2.1.0 watch read the single default record, which
+    # is the iOS one, and wrote it to both channels: `mas` was pinned to 2.0.0
+    # while the Mac App Store was already serving 2.1.0, so a Mac App Store
+    # user on 2.0.0 was told they were up to date.
+    found = {'ios': ios, 'mas': mac, 'play': play}
 
-    changed = False
+    changed = raise_store_channels(channels, previous_channels(args.previous))
     for name, live in found.items():
         if name not in channels or not live:
             continue
-        if channels[name]['version'] != live:
+        # Forwards only: a store that reports an older version than the one
+        # already published is answering from a cache, not un-releasing a
+        # build, and writing it back would silence the notice.
+        if version_tuple(live) > version_tuple(channels[name]['version']):
             print(f'  ✓ {name:5} {channels[name]["version"]} → {live}')
             channels[name]['version'] = live
             changed = True

--- a/test-script/test_store_manifest.py
+++ b/test-script/test_store_manifest.py
@@ -1,0 +1,118 @@
+"""Tests for refresh_store_manifest.py — the Apple half, with no network.
+
+The bug these exist for: the iOS and Mac App Store entries share an app id, so
+the watch read one lookup record and wrote it to both channels. When review
+had approved the Mac build of 2.1.0 and not the iOS one, `mas` was pinned to
+the iOS 2.0.0 and Mac App Store users on 2.0.0 were told they were up to date.
+
+Run from project root:
+    python3 test-script/test_store_manifest.py
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import sys
+import tempfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "test-script"))
+
+import refresh_store_manifest as rsm  # noqa: E402
+
+IOS_RECORD = {"kind": "software", "version": "2.0.0"}
+MAC_RECORD = {"kind": "mac-software", "version": "2.1.0"}
+
+
+def test_picks_the_record_for_the_platform_asked_about():
+    both = [IOS_RECORD, MAC_RECORD]
+    assert rsm.apple_version_of(both, "software") == "2.0.0"
+    assert rsm.apple_version_of(both, "mac-software") == "2.1.0"
+    print("  ok: each platform reads its own record")
+
+
+def test_the_other_platforms_record_is_not_an_answer():
+    # The regression. A Mac lookup that comes back with only the iOS record
+    # must report nothing rather than the iOS version: a channel left behind
+    # keeps the watch running, while a channel pinned to the wrong version
+    # silences the notice for everyone on that store.
+    assert rsm.apple_version_of([IOS_RECORD], "mac-software") is None
+    assert rsm.apple_version_of([MAC_RECORD], "software") is None
+    assert rsm.apple_version_of([], "software") is None
+    print("  ok: a missing record reads as unknown, not as the other platform")
+
+
+def _run_against(tmp, ios_results, mac_results, published=None):
+    """main() over a copy of the manifest, with both stores stubbed out."""
+    manifest = tmp / "updates.json"
+    shutil.copyfile(ROOT / "landing" / "updates.json", manifest)
+
+    def fake_get_json(url, headers=None, data=None, method=None):
+        return {"results": mac_results if "macSoftware" in url else ios_results}
+
+    real_manifest, real_get_json, real_play = rsm.MANIFEST, rsm.get_json, rsm.play_live_version
+    rsm.MANIFEST = str(manifest)
+    rsm.get_json = fake_get_json
+    rsm.play_live_version = lambda _sa: "2.1.0"
+    argv = sys.argv
+    sys.argv = ["refresh_store_manifest.py", "--target", "2.1.0"]
+    if published is not None:
+        previous = tmp / "previous.json"
+        previous.write_text(json.dumps({"channels": published}))
+        sys.argv += ["--previous", str(previous)]
+    try:
+        rsm.main()
+    finally:
+        sys.argv = argv
+        rsm.MANIFEST, rsm.get_json, rsm.play_live_version = real_manifest, real_get_json, real_play
+
+    with open(manifest, encoding="utf-8") as fh:
+        return json.load(fh)["channels"]
+
+
+def test_mac_channel_follows_the_mac_store(tmp):
+    channels = _run_against(tmp, [IOS_RECORD], [MAC_RECORD])
+    assert channels["mas"]["version"] == "2.1.0", channels["mas"]
+    assert channels["ios"]["version"] == "2.0.0", channels["ios"]
+    print("  ok: mas moves to 2.1.0 while ios stays at 2.0.0")
+
+
+def test_an_unreadable_mac_record_leaves_the_channel_alone(tmp):
+    before = json.loads((ROOT / "landing" / "updates.json").read_text())["channels"]
+    channels = _run_against(tmp, [IOS_RECORD], [IOS_RECORD])
+    assert channels["mas"]["version"] == before["mas"]["version"], channels["mas"]
+    print("  ok: mas is left where it was rather than taking the iOS version")
+
+
+def test_a_failed_lookup_keeps_what_was_published(tmp):
+    # main's store entries are moved by hand and lag; the published manifest is
+    # the truth. A run that cannot read the Mac record must republish 2.1.0,
+    # not fall back to main's 1.8 and silence the notice for that store.
+    channels = _run_against(tmp, [IOS_RECORD], [IOS_RECORD],
+                            published={"mas": {"version": "2.1.0"}})
+    assert channels["mas"]["version"] == "2.1.0", channels["mas"]
+    print("  ok: an unanswerable lookup republishes the last known version")
+
+
+def test_a_stale_lookup_does_not_move_a_channel_backwards(tmp):
+    channels = _run_against(tmp, [IOS_RECORD], [{"kind": "mac-software", "version": "2.0.0"}],
+                            published={"mas": {"version": "2.1.0"}})
+    assert channels["mas"]["version"] == "2.1.0", channels["mas"]
+    print("  ok: a lookup answering from cache does not undo a bump")
+
+
+if __name__ == "__main__":
+    print("Running store manifest tests…")
+    _tmp = Path(tempfile.mkdtemp(prefix="opendraft-manifest-"))
+    try:
+        test_picks_the_record_for_the_platform_asked_about()
+        test_the_other_platforms_record_is_not_an_answer()
+        test_mac_channel_follows_the_mac_store(_tmp)
+        test_an_unreadable_mac_record_leaves_the_channel_alone(_tmp)
+        test_a_failed_lookup_keeps_what_was_published(_tmp)
+        test_a_stale_lookup_does_not_move_a_channel_backwards(_tmp)
+        print("All tests passed.")
+    finally:
+        shutil.rmtree(_tmp, ignore_errors=True)


### PR DESCRIPTION
## What does this PR do?

Fixes the in-app update notice staying silent on the Mac App Store. A user on 2.0.0 with 2.1.0 live in the store was told nothing, because the manifest the app reads had `mas` pinned to 2.0.0 — so `decideNotice()` correctly concluded there was nothing to offer.

The store watch put it there. `refresh_store_manifest.py` asked the iTunes lookup **once**, on the documented assumption that one record covers both Apple entries for this app id, and wrote that answer to the `ios` and `mas` channels together. The default record is the iOS one. The two platforms are separate records at separate versions — review approves the iOS and Mac builds separately, so either can be a release ahead — and on v2.1.0 they were: [run #11](https://github.com/Proteus-Technologies-Private-Limited/OpenDraft/actions/runs/33814387834) logged `apple live: 2.0.0` and moved both channels there while the Mac App Store was already serving 2.1.0.

Each storefront is now asked for itself — `software` for iOS, `mac-software` (via `entity=macSoftware`) for the Mac App Store — and the `kind` of the record that comes back is checked rather than trusted: a lookup that cannot serve the entity asked for answers with the record it has, and taking that is exactly how one platform's version became the other's. A record that is missing reads as unknown, which leaves that channel behind and keeps the watch running (and files its give-up issue after 14 days), rather than pinning it wrong and silencing the notice.

Missing records are newly reachable, which exposed a second hole in the same failure class: every run recomposes the manifest from `main`, whose store entries are moved by hand and were still on 1.8, so one unanswerable lookup would have republished 1.8 and taken the notice away from that store until a later run happened to succeed. The versions last published are now passed in from the `manifest` branch as floors (`--previous`), and a lookup can only move a channel forwards — a store reporting an older version is answering from a cache, not un-releasing a build.

Nothing on the app side changed, and nothing there needed to: `VITE_OPENDRAFT_CHANNEL: mas` is set on the App Store build, `UpdateBanner` is mounted at the App root, the CSP allows `raw.githubusercontent.com`, and `getAppVersion()` is bumped per release by `release.sh`.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring (no functional change)
- [x] Documentation
- [ ] Other (describe below)

## How was this tested?

`test-script/test_store_manifest.py` (new, no network — the lookup and the Play call are both stubbed) covers:

- each platform reading its own record;
- a missing record reading as unknown instead of borrowing the other platform's version;
- `mas` moving to the Mac version while `ios` stays behind, over a real copy of `landing/updates.json`;
- a failed lookup republishing the last published version rather than `main`'s stale one;
- a stale lookup not undoing a bump.

```
$ python3 test-script/test_store_manifest.py
Running store manifest tests…
  ok: each platform reads its own record
  ok: a missing record reads as unknown, not as the other platform
  ok: mas moves to 2.1.0 while ios stays at 2.0.0
  ok: mas is left where it was rather than taking the iOS version
  ok: an unanswerable lookup republishes the last known version
  ok: a lookup answering from cache does not undo a bump
All tests passed.
```

The two live records could not be read from the authoring environment (`itunes.apple.com` and `apps.apple.com` are both blocked by its egress proxy), so which platform is behind is inferred from the CI log plus the report of 2.1.0 in the store. The fix holds either way round, since each channel now follows its own storefront — and the next watch run prints `apple ios live` and `apple mac live` separately, which confirms it.

**After merge:** the watch does `checkout ref: main`, so this takes effect on its next run — it is enabled and wakes every ~30 minutes. Installed apps cache the manifest for 24 h; **Help → Check for Updates** forces a fetch and ignores the throttle, the snooze and any dismissal.

## Screenshots (if applicable)

n/a — no UI change.

## Checklist

- [x] I've read the [Contributing Guide](docs/CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I've tested my changes locally
- [x] I've updated documentation if needed (`docs/RELEASE.md`, corrected on both points)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CkednXW2syRngFMzPjFyLW

---
_Generated by [Claude Code](https://claude.ai/code/session_01CkednXW2syRngFMzPjFyLW)_